### PR TITLE
Use Duration from time crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ enum_primitive = "0.0.2"
 num = "0.1.24"
 byteorder = "0.3.9"
 schedule_recv = "0.0.1"
+time = "0.1.26"
 
 [features]
 unstable = []

--- a/examples/zookeeper_example.rs
+++ b/examples/zookeeper_example.rs
@@ -1,11 +1,11 @@
 #![feature(duration)]
 extern crate zookeeper;
 
-use std::time::Duration;
 use std::thread;
 use std::io;
 use zookeeper::{Acl, CreateMode, Watcher, WatchedEvent, ZkResult, ZooKeeper};
 use zookeeper::perms;
+use zookeeper::Duration;
 
 struct LoggingWatcher;
 impl Watcher for LoggingWatcher {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,14 +1,16 @@
-#![feature(duration, std_misc)]
+#![feature(std_misc)]
 #![deny(unused_mut)]
 #[macro_use]
 extern crate enum_primitive;
 extern crate num;
 extern crate byteorder;
 extern crate schedule_recv;
+extern crate time;
 
 pub use consts::*;
 pub use proto::{Acl, Stat, WatchedEvent};
 pub use zookeeper::*;
+pub use time::Duration;
 
 mod consts;
 mod proto;

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -1,7 +1,7 @@
 use byteorder::{ReadBytesExt, WriteBytesExt, BigEndian};
 use consts::{KeeperState, WatchedEventType, ZkError};
 use std::io::{Read, Write, Result, Error, ErrorKind};
-use std::time::Duration;
+use time::Duration;
 use num::FromPrimitive;
 
 trait StringReader: Read {
@@ -190,7 +190,7 @@ impl ConnectResponse {
     pub fn initial(timeout: Duration) -> ConnectResponse {
         ConnectResponse{
             protocol_version: 0,
-            timeout: timeout.secs() as i32 * 1000,
+            timeout: timeout.num_seconds() as i32 * 1000,
             session_id: 0,
             passwd: [0;16].to_vec(),
             read_only: false}

--- a/src/zookeeper.rs
+++ b/src/zookeeper.rs
@@ -7,8 +7,8 @@ use std::result;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicIsize, Ordering};
 use std::sync::mpsc::{channel, Receiver, Sender, SyncSender, sync_channel};
-use std::time::Duration;
 use std::thread;
+use time::Duration;
 use num::FromPrimitive;
 use schedule_recv::periodic_ms;
 
@@ -100,7 +100,7 @@ impl ZooKeeper {
         thread::spawn(move || {
             println!("Writer: thread started");
 
-            let ping_timeout = periodic_ms(timeout.secs() as u32 * 1000);
+            let ping_timeout = periodic_ms(timeout.num_seconds() as u32 * 1000);
             let mut writer_sock;
             let mut conn_resp = ConnectResponse::initial(timeout);
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -7,7 +7,7 @@ use zookeeper::perms;
 
 use std::io::{BufRead, BufReader};
 use std::process::{Child, Command, Stdio};
-use std::time::Duration;
+use time::Duration;
 
 struct LoggingWatcher;
 impl Watcher for LoggingWatcher {


### PR DESCRIPTION
The library is still unstable from `std_misc`, but it's a start.

Also, it looks like the methods changed from `Duration.seconds` to `Duration.num_seconds`.