### PR TITLE
path children cach

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.iml
 target
 Cargo.lock
+*~

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ log = "0.3"
 mio = { git = "https://github.com/carllerche/mio.git" }
 num = "0.1"
 time = "0.1"
+snowflake = "1.0.0"
 
 [dev-dependencies]
 env_logger = "0.3"

--- a/examples/zookeeper_example.rs
+++ b/examples/zookeeper_example.rs
@@ -11,6 +11,7 @@ use std::thread;
 use std::env;
 use zookeeper::{CreateMode, Watcher, WatchedEvent, ZooKeeper};
 use zookeeper::acls;
+use zookeeper::recipes::cache::{PathChildrenCache};
 
 struct LoggingWatcher;
 impl Watcher for LoggingWatcher {
@@ -29,7 +30,10 @@ fn zk_server_urls() -> String {
 
 
 fn zk_example() {
-    let zk = ZooKeeper::connect(&*zk_server_urls(), Duration::from_secs(5), LoggingWatcher).unwrap();
+    let zk_urls = zk_server_urls();
+    println!("connecting to {}", zk_urls);
+    
+    let zk = ZooKeeper::connect(&*zk_urls, Duration::from_secs(5), LoggingWatcher).unwrap();
 
     let mut tmp = String::new();
 
@@ -73,19 +77,27 @@ fn zk_example() {
 
     // println!("deleted /test -> {:?}", delete);
 
-    let watch_children = zk.get_children_w("/", LoggingWatcher);
-    println!("watch children -> {:?}", watch_children);
+    let watch_children = zk.get_children_w("/", |event: &WatchedEvent| {
+        println!("watched event {:?}", event);
+    });
     
+    println!("watch children -> {:?}", watch_children);
+
+    let zk_arc = Arc::new(zk);
+    
+    let mut pcc = PathChildrenCache::new(zk_arc.clone(), "/").unwrap();
+    pcc.start();
+
     println!("press enter to close client");
     io::stdin().read_line(&mut tmp).unwrap();
 
     // The client can be shared between tasks
-    let zk = Arc::new(zk);
+    let zk_arc_captured = zk_arc.clone();
     thread::spawn(move || {
-        zk.close().unwrap();
+        zk_arc_captured.close().unwrap();
 
         // And operations return error after closed
-        match zk.exists("/test", false) {
+        match zk_arc_captured.exists("/test", false) {
             Err(err) => println!("Usage after closed should end up with error: {:?}", err),
             Ok(_) => panic!("Shouldn't happen")
         }

--- a/examples/zookeeper_example.rs
+++ b/examples/zookeeper_example.rs
@@ -8,6 +8,7 @@ use std::io;
 use std::sync::Arc;
 use std::time::Duration;
 use std::thread;
+use std::env;
 use zookeeper::{CreateMode, Watcher, WatchedEvent, ZooKeeper};
 use zookeeper::acls;
 
@@ -18,8 +19,17 @@ impl Watcher for LoggingWatcher {
     }
 }
 
+fn zk_server_urls() -> String {
+    let key = "ZOOKEEPER_SERVERS";
+    match env::var(key) {
+        Ok(val) => val,
+        Err(_) => "localhost:2181".to_string(),
+    }
+}
+
+
 fn zk_example() {
-    let zk = ZooKeeper::connect("localhost:2181/", Duration::from_secs(5), LoggingWatcher).unwrap();
+    let zk = ZooKeeper::connect(&*zk_server_urls(), Duration::from_secs(5), LoggingWatcher).unwrap();
 
     let mut tmp = String::new();
 
@@ -63,6 +73,9 @@ fn zk_example() {
 
     // println!("deleted /test -> {:?}", delete);
 
+    let watch_children = zk.get_children_w("/", LoggingWatcher);
+    println!("watch children -> {:?}", watch_children);
+    
     println!("press enter to close client");
     io::stdin().read_line(&mut tmp).unwrap();
 

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -57,7 +57,7 @@ enum_from_primitive! {
 }
 
 /// Enumeration of states the client may be at any time
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ZkState {
     Associating,
     AuthFailed,

--- a/src/io.rs
+++ b/src/io.rs
@@ -114,7 +114,7 @@ impl ZkHandler {
 
         debug!("handle_response in {:?} state [{}]", self.state, data.bytes().len());
 
-        if self.state != ZkState::NotConnected {
+        if self.state != ZkState::Connecting {
             let header = match ReplyHeader::read_from(&mut data) {
                 Ok(header) => header,
                 Err(e) => {

--- a/src/io.rs
+++ b/src/io.rs
@@ -91,7 +91,7 @@ impl ZkHandler {
     }
 
     fn notify_state(&self, old_state: ZkState, new_state: ZkState) {
-        if(new_state != old_state) {
+        if new_state != old_state {
             self.state_listeners.notify(&new_state);
         }
     }

--- a/src/io.rs
+++ b/src/io.rs
@@ -2,6 +2,7 @@ use consts::{OpCode, ZkError, ZkState};
 use proto::{ByteBuf, ConnectRequest, ConnectResponse, ReadFrom, ReplyHeader, RequestHeader, WriteTo};
 use watch::WatchMessage;
 use zookeeper::{RawResponse, RawRequest};
+use listeners::{ListenerSet};
 
 use byteorder::{BigEndian, ByteOrder};
 use bytes::{Buf, RingBuf};
@@ -55,11 +56,12 @@ struct ZkHandler {
     watch_sender: Sender<WatchMessage>,
     conn_resp: ConnectResponse,
     zxid: i64,
-    ping_sent: PreciseTime
+    ping_sent: PreciseTime,
+    state_listeners: ListenerSet<ZkState>,
 }
 
 impl ZkHandler {
-    fn new(addrs: Vec<SocketAddr>, timeout_ms: u64, watch_sender: Sender<WatchMessage>) -> ZkHandler {
+    fn new(addrs: Vec<SocketAddr>, timeout_ms: u64, watch_sender: Sender<WatchMessage>, state_listeners: ListenerSet<ZkState>) -> ZkHandler {
         ZkHandler{
             sock: unsafe{mem::dropped()},
             state: ZkState::NotConnected,
@@ -73,7 +75,8 @@ impl ZkHandler {
             watch_sender: watch_sender,
             conn_resp: ConnectResponse::initial(timeout_ms),
             zxid: 0,
-            ping_sent: PreciseTime::now()
+            ping_sent: PreciseTime::now(),
+            state_listeners: state_listeners,
         }
     }
 
@@ -85,6 +88,12 @@ impl ZkHandler {
     fn reregister(&mut self, event_loop: &mut EventLoop<Self>, events: EventSet) {
         event_loop.reregister(&self.sock, ZK, events, PollOpt::edge() | PollOpt::oneshot())
         .ok().expect("Failed to reregister ZK handle");
+    }
+
+    fn notify_state(&self, old_state: ZkState, new_state: ZkState) {
+        if(new_state != old_state) {
+            self.state_listeners.notify(&new_state);
+        }
     }
 
     fn handle_response(&mut self, event_loop: &mut EventLoop<Self>) {
@@ -137,7 +146,9 @@ impl ZkHandler {
                 _ => match self.inflight.pop_front() {
                     Some(request) => {
                         if request.opcode == OpCode::CloseSession {
+                            let old_state = self.state;
                             self.state = ZkState::Closed;
+                            self.notify_state(old_state, self.state);
                             event_loop.shutdown();
                         }
                         self.send_response(request, response);
@@ -157,9 +168,12 @@ impl ZkHandler {
             };
             info!("Connected: {:?}", self.conn_resp);
             self.timeout_ms = self.conn_resp.timeout / 3 * 2;
+
+            let old_state = self.state;
             self.state = if self.conn_resp.read_only {
                 ZkState::ConnectedReadOnly } else {
                 ZkState::Connected };
+            self.notify_state(old_state, self.state);
         }
     }
 
@@ -183,7 +197,10 @@ impl ZkHandler {
     }
 
     fn reconnect(&mut self, event_loop: &mut EventLoop<Self>) {
+        let old_state = self.state;
         self.state = ZkState::Connecting;
+        self.notify_state(old_state, self.state);
+        
         // TODO only until session times out
         loop {
             self.buffer.clear();
@@ -281,7 +298,10 @@ impl Handler for ZkHandler {
                 //         Err(e) => panic!("Reader/Writer: Event died {}", e)
                 //     }
                 // }
+                let old_state = self.state;
                 self.state = ZkState::NotConnected;
+                self.notify_state(old_state, self.state);
+                
                 self.reconnect(event_loop);
             }
         }
@@ -330,10 +350,10 @@ pub struct ZkIo {
 }
 
 impl ZkIo {
-    pub fn new(addrs: Vec<SocketAddr>, timeout: Duration, event_sender: Sender<WatchMessage>) -> ZkIo {
+    pub fn new(addrs: Vec<SocketAddr>, timeout: Duration, event_sender: Sender<WatchMessage>, state_listeners: ListenerSet<ZkState>) -> ZkIo {
         let event_loop = EventLoop::new().unwrap();
         let timeout_ms = timeout.as_secs() * 1000 + timeout.subsec_nanos() as u64 / 1000000;
-        let handler = ZkHandler::new(addrs, timeout_ms, event_sender);
+        let handler = ZkHandler::new(addrs, timeout_ms, event_sender, state_listeners);
         ZkIo{event_loop: event_loop, handler: handler}
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ extern crate lazy_static;
 extern crate log;
 extern crate mio;
 extern crate time;
+extern crate snowflake;
 
 pub use consts::*;
 pub use proto::{Acl, Stat, WatchedEvent};
@@ -25,6 +26,7 @@ mod consts;
 mod io;
 mod proto;
 mod watch;
+mod listeners;
 mod zoodefs;
 mod zookeeper;
 mod zookeeper_ext;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #![feature(fnbox)]
 #![feature(filling_drop)]
+#![feature(mpsc_select)]
 #![deny(unused_mut)]
 extern crate byteorder;
 extern crate bytes;

--- a/src/listeners.rs
+++ b/src/listeners.rs
@@ -67,7 +67,7 @@ mod tests {
     #[test]
     fn test_new_listener_for_chan() {
         let (tx, _rx) = mpsc::channel();
-        let mut ls = ListenerSet::<bool>::new();
+        let ls = ListenerSet::<bool>::new();
 
         ls.subscribe(tx);
     }
@@ -75,7 +75,7 @@ mod tests {
     #[test]
     fn test_add_listener_to_set() {        
         let (tx, rx) = mpsc::channel();
-        let mut ls = ListenerSet::<bool>::new();
+        let ls = ListenerSet::<bool>::new();
 
         ls.subscribe(tx);
         ls.notify(&true);
@@ -86,7 +86,7 @@ mod tests {
     #[test]
     fn test_remove_listener_from_set() {
         let (tx, rx) = mpsc::channel();
-        let mut ls = ListenerSet::<bool>::new();
+        let ls = ListenerSet::<bool>::new();
 
         let sub = ls.subscribe(tx);
         ls.unsubscribe(sub);

--- a/src/listeners.rs
+++ b/src/listeners.rs
@@ -70,6 +70,7 @@ impl<T> ListenerSet<T> where T: Send + Clone {
         }
     }
 
+    #[allow(dead_code)]
     pub fn len(&self) -> usize {
         self.listeners.lock().unwrap().len()
     }

--- a/src/listeners.rs
+++ b/src/listeners.rs
@@ -25,7 +25,7 @@ impl<T> ListenerSet<T> where T: Send + Clone {
         }
     }
     
-    fn subscribe(&mut self, listener: Sender<T>) -> Subscription {
+    pub fn subscribe(&self, listener: Sender<T>) -> Subscription {
         let mut acquired_listeners = self.listeners.lock().unwrap();
 
         let subscription = Subscription::new();
@@ -34,22 +34,14 @@ impl<T> ListenerSet<T> where T: Send + Clone {
         subscription
     }
 
-    fn unsubscribe(&mut self, sub: Subscription) {
+    pub fn unsubscribe(&self, sub: Subscription) {
         let mut acquired_listeners = self.listeners.lock().unwrap();
 
         // channel will be close here automatically
         acquired_listeners.remove(&sub);
-        
-/*        match acquired_listeners.remove(&sub) {
-            Some(chan) => {
-                drop(chan);
-            },
-            None => {
-            }
-        }*/
     }
     
-    fn notify(&self, payload: &T) {
+    pub fn notify(&self, payload: &T) {
         let acquired_listeners = self.listeners.lock().unwrap();
         
         for listener in acquired_listeners.iter() {

--- a/src/listeners.rs
+++ b/src/listeners.rs
@@ -1,0 +1,106 @@
+
+use std::collections::HashMap;
+use std::sync::{Arc,Mutex};
+use std::sync::mpsc::Sender;
+use snowflake::ProcessUniqueId;
+
+#[derive(Debug,Clone,Eq,PartialEq,Hash)]
+pub struct Subscription(ProcessUniqueId);
+
+impl Subscription {
+    fn new() -> Subscription {
+        Subscription(ProcessUniqueId::new())
+    }
+}
+
+#[derive(Clone)]
+pub struct ListenerSet<T> where T: Send {
+    listeners: Arc<Mutex<HashMap<Subscription, Sender<T>>>>,
+}
+
+impl<T> ListenerSet<T> where T: Send + Clone {
+    pub fn new() -> Self {
+        ListenerSet{
+            listeners: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+    
+    fn subscribe(&mut self, listener: Sender<T>) -> Subscription {
+        let mut acquired_listeners = self.listeners.lock().unwrap();
+
+        let subscription = Subscription::new();
+        acquired_listeners.insert(subscription.clone(), listener);
+
+        subscription
+    }
+
+    fn unsubscribe(&mut self, sub: Subscription) {
+        let mut acquired_listeners = self.listeners.lock().unwrap();
+
+        // channel will be close here automatically
+        acquired_listeners.remove(&sub);
+        
+/*        match acquired_listeners.remove(&sub) {
+            Some(chan) => {
+                drop(chan);
+            },
+            None => {
+            }
+        }*/
+    }
+    
+    fn notify(&self, payload: &T) {
+        let acquired_listeners = self.listeners.lock().unwrap();
+        
+        for listener in acquired_listeners.iter() {
+            Self::notify_listener(listener.1, payload);
+        }
+    }
+
+    fn notify_listener(chan: &Sender<T>, payload: &T) {
+        chan.send(payload.clone());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ListenerSet,Subscription};
+    use std::sync::mpsc;
+
+    #[test]
+    fn test_new_listener_set() {
+        let ls = ListenerSet::<()>::new();
+    }
+
+    #[test]
+    fn test_new_listener_for_chan() {
+        let (tx, _rx) = mpsc::channel();
+        let mut ls = ListenerSet::<bool>::new();
+
+        ls.subscribe(tx);
+    }
+    
+    #[test]
+    fn test_add_listener_to_set() {        
+        let (tx, rx) = mpsc::channel();
+        let mut ls = ListenerSet::<bool>::new();
+
+        ls.subscribe(tx);
+        ls.notify(&true);
+
+        assert_eq!(rx.recv().is_ok(), true);
+    }
+
+    #[test]
+    fn test_remove_listener_from_set() {
+        let (tx, rx) = mpsc::channel();
+        let mut ls = ListenerSet::<bool>::new();
+
+        let sub = ls.subscribe(tx);
+        ls.unsubscribe(sub);
+        
+        ls.notify(&true);
+        
+        assert_eq!(rx.recv().is_err(), true);
+    }
+}

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -58,7 +58,8 @@ impl <R: Read> StringReader for R {
 // A buffer is an u8 string prefixed with it's length as i32
 impl <R: Read> BufferReader for R {
     fn read_buffer(&mut self) -> Result<Vec<u8>> {
-        let len = try!(self.read_i32::<BigEndian>()) as usize;
+        let len = try!(self.read_i32::<BigEndian>());
+        let len = if len < 0 { 0 } else { len as usize };
         let mut buf = vec![0; len];
         let read = try!(self.read(&mut buf));
         if read == len {

--- a/src/recipes/cache.rs
+++ b/src/recipes/cache.rs
@@ -75,7 +75,7 @@ impl PathChildrenCache {
         let watcher = move |event: &WatchedEvent| {
             match event.event_type {
                 WatchedEventType::NodeChildrenChanged => {
-                    let path = event.path.as_ref().expect("Path absent");
+                    let _path = event.path.as_ref().expect("Path absent");
 
                     // Subscribe to new changes recursively
                     match ops_chan1.send(Operation::Refresh(RefreshMode::Standard, None)) {

--- a/src/recipes/cache.rs
+++ b/src/recipes/cache.rs
@@ -179,6 +179,13 @@ impl PathChildrenCache {
                         match state {
                             Ok(state) => {
                                 info!("zk state change {:?}", state);
+                                match state {
+                                    ZkState::Connected => {
+                                        ops_chan_tx.send(Operation::Refresh(RefreshMode::ForceGetDataAndStat, None));
+                                    },
+                                    _ => {
+                                    }
+                                }
                             },
                             Err(err) => {
                                 info!("zk state chan err. shutting down. {:?}", err);

--- a/src/zookeeper.rs
+++ b/src/zookeeper.rs
@@ -8,7 +8,6 @@ use watch::{Watch, Watcher, WatchType, ZkWatch};
 use std::io::{Read, Result};
 use std::net::{SocketAddr, ToSocketAddrs};
 use std::result;
-use std::sync::{Arc, Mutex};
 use std::sync::atomic::{AtomicIsize, Ordering};
 use std::sync::mpsc::{Sender, sync_channel, SyncSender};
 use std::time::Duration;
@@ -278,7 +277,12 @@ impl ZooKeeper {
 impl Drop for ZooKeeper {
     fn drop(&mut self) {
         // TODO First check if state is closed
-        let _ = self.close();
+        match self.close() {
+            Err(err) => {
+                info!("error closing zookeeper connection in drop: {:?}", err);
+            },
+            _ => {}
+        }
     }
 }
 


### PR DESCRIPTION
as discussed, here's a working pcc.
also included:
 1. the fix to cope with null data values being represented in the wire protocol as -1 i32 values.
 2. some downgrades of logging lines from debug to trace to clean up the output for general users

things that could change in the future:
 1. constructors
 2. initialisation options and events
 3. error handling