### PR TITLE
detect expired session and reconnect if timeout while request inflight

### DIFF
--- a/src/proto.rs
+++ b/src/proto.rs
@@ -190,7 +190,7 @@ impl WriteTo for ConnectRequest {
 pub struct ConnectResponse {
     protocol_version: i32,
     pub timeout: u64, // is handled as i32
-    session_id: i64,
+    pub session_id: i64,
     passwd: Vec<u8>,
     pub read_only: bool
 }


### PR DESCRIPTION
I've been trying to test what happens if we get connectionloss while waiting for a response.
to simulate that I run the zookeeper_example with a console.readline just before a sensitive request, then i run
sudo iptables -I FORWARD -p tcp --sport 2181 -j DROP
then i run the request and wait for two thirds of the negotiated timeout to elapse.
then quickly run
sudo iptables -D FORWARD 1

the desired behaviour is that the client times out and tries to reconnect before the server forceably times out and deletes the client's session and ephemeral nodes.

if the session is deleted because we waited too long, the server sends back a ConnectResponse with all zeroes, which the java zk client detects by checking for a negotiated timeout <= 0.
before this pull request, we overwrote the self.conn_resp with that all-zero ConnectResponse. this would correctly zero the session_id, but also useful data like the desired timeout_ms.

further, if we manage to reestablish connectivity before the server removes our session, we should get back the same session_id in the response as sent in the reconnect request, and we should see that our ephemeral nodes are not removed.
before this pull request, the ping timeout would only send ping packets, but never trigger a reconnect in the event of no response.
i've changed it so that ping is only used during periods of idleness when no request is in flight. when a request is in flight and we're expecting a response, then a timeout means we need to immediately try reconnecting.