### PR TITLE
Add recursive get_children and delete methods to ZooKeeperExt

### DIFF
--- a/src/zookeeper_ext.rs
+++ b/src/zookeeper_ext.rs
@@ -2,12 +2,22 @@ use acl::*;
 use consts::{CreateMode, ZkError};
 use zookeeper::{ZkResult, ZooKeeper};
 use std::iter::once;
+use std::collections::VecDeque;
 
 /// Extended ZooKeeper operations that are not needed for the "core."
 pub trait ZooKeeperExt {
     /// Ensure that `path` exists and create all potential paths leading up to it if it does not.
     /// This operates in a manner similar to `mkdir -p`.
     fn ensure_path(&self, path: &str) -> ZkResult<()>;
+
+    /// Performs a breadth-first tree traversal of the tree starting at `path`,
+    /// returning a list of fully prefixed child nodes.
+    /// *NOTE*: This is not an atomic operation.
+    fn get_children_recursive(&self, path: &str) -> ZkResult<Vec<String>>;
+
+    /// Deletes the node at `path` and all its children.
+    /// *NOTE*: This is not an atomic operation.
+    fn delete_recursive(&self, path: &str) -> ZkResult<()>;
 }
 
 impl ZooKeeperExt for ZooKeeper {
@@ -25,6 +35,34 @@ impl ZooKeeperExt for ZooKeeper {
                 Err(e) => return Err(e),
             }
         }
+        Ok(())
+    }
+
+    fn get_children_recursive(&self, path: &str) -> ZkResult<Vec<String>> {
+        let mut queue: VecDeque<String> = VecDeque::new();
+        let mut result = vec![path.to_string()];
+        queue.push_front(path.to_string());
+
+        while let Some(current) = queue.pop_front() {
+            let children = self.get_children(&current, false)?;
+            children
+                .into_iter()
+                .map(|child| format!("{}/{}", current, child))
+                .for_each(|full_path| {
+                    result.push(full_path.clone());
+                    queue.push_back(full_path);
+                });
+        }
+
+        Ok(result)
+    }
+
+    fn delete_recursive(&self, path: &str) -> ZkResult<()> {
+        let children = self.get_children_recursive(path)?;
+        for child in children.iter().rev() {
+            self.delete(child, None)?;
+        }
+
         Ok(())
     }
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -6,6 +6,7 @@ extern crate zookeeper;
 
 mod test_zk;
 mod test_cache;
+mod test_recursive;
 
 use std::io::{BufRead, BufReader, Write};
 use std::process::{Child, Command, Stdio};

--- a/tests/test_recursive.rs
+++ b/tests/test_recursive.rs
@@ -1,0 +1,130 @@
+use zookeeper::{WatchedEvent, ZkError, ZooKeeper, ZooKeeperExt};
+
+use ZkCluster;
+
+use std::iter::once;
+use std::time::Duration;
+
+#[test]
+fn get_children_recursive_test() {
+    // Create a test cluster
+    let cluster = ZkCluster::start(1);
+
+    // Connect to the test cluster
+    let zk = ZooKeeper::connect(
+        &cluster.connect_string,
+        Duration::from_secs(30),
+        |_: WatchedEvent| {},
+    ).unwrap();
+
+    let tree = vec![
+        "/root/a/1",
+        "/root/a/2",
+        "/root/a/3",
+        "/root/b/1",
+        "/root/b/2",
+        "/root/b/3",
+        "/root/c/1",
+        "/root/c/2",
+        "/root/c/3",
+    ];
+
+    for path in tree.iter() {
+        zk.ensure_path(path).unwrap();
+    }
+
+    let children = zk.get_children_recursive("/root").unwrap();
+    for path in tree {
+        for (i, _) in path.chars()
+            .chain(once('/'))
+            .enumerate()
+            .skip(1)
+            .filter(|c| c.1 == '/')
+        {
+            assert!(children.contains(&path[..i].to_string()));
+        }
+    }
+}
+
+#[test]
+fn get_children_recursive_invalid_path_test() {
+    // Create a test cluster
+    let cluster = ZkCluster::start(1);
+
+    // Connect to the test cluster
+    let zk = ZooKeeper::connect(
+        &cluster.connect_string,
+        Duration::from_secs(30),
+        |_: WatchedEvent| {},
+    ).unwrap();
+
+    let result = zk.get_children_recursive("/bad");
+    assert_eq!(result, Err(ZkError::NoNode))
+}
+
+#[test]
+fn get_children_recursive_only_root_test() {
+    // Create a test cluster
+    let cluster = ZkCluster::start(1);
+
+    // Connect to the test cluster
+    let zk = ZooKeeper::connect(
+        &cluster.connect_string,
+        Duration::from_secs(30),
+        |_: WatchedEvent| {},
+    ).unwrap();
+
+    let root = "/root";
+    zk.ensure_path(root).unwrap();
+    let result = zk.get_children_recursive(root).unwrap();
+    assert_eq!(result, vec![root]);
+}
+
+#[test]
+fn delete_recursive_test() {
+    // Create a test cluster
+    let cluster = ZkCluster::start(1);
+
+    // Connect to the test cluster
+    let zk = ZooKeeper::connect(
+        &cluster.connect_string,
+        Duration::from_secs(30),
+        |_: WatchedEvent| {},
+    ).unwrap();
+
+    let tree = vec![
+        "/root/a/1",
+        "/root/a/2",
+        "/root/a/3",
+        "/root/b/1",
+        "/root/b/2",
+        "/root/b/3",
+        "/root/c/1",
+        "/root/c/2",
+        "/root/c/3",
+    ];
+
+    for path in tree.iter() {
+        zk.ensure_path(path).unwrap();
+    }
+
+    zk.delete_recursive("/root/a").unwrap();
+    assert!(zk.exists("/root/a", false).unwrap().is_none());
+    assert!(zk.exists("/root/b", false).unwrap().is_some());
+}
+
+#[test]
+fn delete_recursive_invalid_path_test() {
+    // Create a test cluster
+    let cluster = ZkCluster::start(1);
+
+    // Connect to the test cluster
+    let zk = ZooKeeper::connect(
+        &cluster.connect_string,
+        Duration::from_secs(30),
+        |_: WatchedEvent| {},
+    ).unwrap();
+
+    let result = zk.delete_recursive("/bad");
+    assert_eq!(result, Err(ZkError::NoNode))
+}


### PR DESCRIPTION
This implements the recursive `delete` and `get_children` methods from [`ZKUtil`](https://github.com/apache/zookeeper/blob/master/src/java/main/org/apache/zookeeper/ZKUtil.java) in the Java client. 