### PR TITLE
Do not update ZXID for session and watch events.

### DIFF
--- a/src/io.rs
+++ b/src/io.rs
@@ -173,7 +173,10 @@ impl ZkIo {
                     return;
                 }
             };
-            self.zxid = header.zxid;
+            if header.zxid > 0 {
+                // Update last-seen zxid when this is a request response
+                self.zxid = header.zxid;
+            }
             let response = RawResponse {
                 header: header,
                 data: Cursor::new(data.bytes().to_vec()),


### PR DESCRIPTION
Previously, the client's ZXID would be updated with every message from
the server. This corrects the behavior to only update the last-seen ZXID
when the server provides one. This stops the client from potentially
going backwards in time during a reconnect event.

The changeset fixes issue #50.