### PR TITLE
Fix reconnection hangup

### DIFF
--- a/src/io.rs
+++ b/src/io.rs
@@ -300,7 +300,7 @@ impl ZkIo {
             },
         }
         self.poll.reregister(&self.timer, TIMER, Ready::readable(), pollopt())
-            .expect("Register TIMER");
+            .expect("Reregister TIMER");
     }
 
     fn reconnect(&mut self) {
@@ -488,7 +488,7 @@ impl ZkIo {
     }
 
     fn ready_timer(&mut self, _: Ready) {
-        trace!("ready_timer; thread={:?}", ::std::thread::current().id());
+        trace!("ready_timer thread={:?}", ::std::thread::current().id());
 
         loop {
             match self.timer.poll() {
@@ -508,7 +508,7 @@ impl ZkIo {
                     }
                 },
                 Some(ZkTimeout::Connect) => {
-                    trace!("handle ping timeout");
+                    trace!("handle connection timeout");
                     self.clear_timeout(ZkTimeout::Connect);
                     if self.state == ZkState::Connecting {
                         info!("Reconnect due to connection timeout");
@@ -519,7 +519,7 @@ impl ZkIo {
                     if self.ping_timeout.is_some() || self.conn_timeout.is_some() {
                         trace!("Spurious timer");
                         self.poll.reregister(&self.timer, TIMER, Ready::readable(), pollopt())
-                            .expect("Register TIMER");
+                            .expect("Reregister TIMER");
                     }
                     break;
                 }

--- a/src/io.rs
+++ b/src/io.rs
@@ -227,7 +227,7 @@ impl ZkIo {
             } else {
                 self.conn_resp = conn_resp;
                 info!("Connected: {:?}", self.conn_resp);
-                self.timeout_ms = self.conn_resp.timeout / 3 * 2;
+                self.timeout_duration = Duration::from_millis(self.conn_resp.timeout / 3 * 2);
 
                 self.state = if self.conn_resp.read_only {
                     ZkState::ConnectedReadOnly

--- a/src/io.rs
+++ b/src/io.rs
@@ -529,6 +529,7 @@ impl ZkIo {
                 Some(_) => {
                     self.clear_timeout(CONN_TIMER);
                     if self.state == ZkState::Connecting {
+                        info!("Reconnect due to connection timeout");
                         self.reconnect();
                     }
                 },

--- a/src/io.rs
+++ b/src/io.rs
@@ -237,6 +237,7 @@ impl ZkIo {
             } else {
                 self.conn_resp = conn_resp;
                 info!("Connected: {:?}", self.conn_resp);
+                self.timeout_ms = self.conn_resp.timeout;
                 self.ping_timeout_duration = Duration::from_millis(self.conn_resp.timeout / 3 * 2);
 
                 self.state = if self.conn_resp.read_only {

--- a/src/io.rs
+++ b/src/io.rs
@@ -95,7 +95,7 @@ impl ZkIo {
 
         let mut zkio = ZkIo {
             sock: TcpStream::connect(&addrs[0]).unwrap(), // TODO I need a socket here, sorry.
-            state: ZkState::NotConnected,
+            state: ZkState::Connecting,
             hosts: Hosts::new(addrs),
             buffer: VecDeque::new(),
             inflight: VecDeque::new(),


### PR DESCRIPTION
- I believe that right after the start "ZkState" should be " Connecting"
- If after connecting to the server to adjust the session timeout instead of ping, "ioloop" will stop more often, even with a valid session
- When hang " Tcp Stream.connect", always occurred halt " io loop". I made an attempt to support tcp connection timeout via timers.

still new-ish to rust and english :-( 