### PR TITLE
Bump dependency versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ snowflake = "1.0.0"
 zookeeper_derive = { path = "zookeeper-derive", version = "0.4.0" }
 
 [dev-dependencies]
-env_logger = "0.5"
+env_logger = "0.6"
 
 [features]
 unstable = []

--- a/zookeeper-derive/Cargo.toml
+++ b/zookeeper-derive/Cargo.toml
@@ -10,5 +10,5 @@ proc-macro = true
 
 [dependencies]
 quote = "0.6.3"
-syn = "0.14.4"
+syn = "0.15.40"
 #proc-macro2 = { version = "0.4", features = ["nightly"] }


### PR DESCRIPTION
This bumps the `syn` dependency, which is pretty costly to have to double-compile in downstream crates, and `env_logger` which is common enough that keeping it up-to-date reduces bloat.