### PR TITLE
Add LeaderLatch recipe

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ zookeeper_derive = { path = "zookeeper-derive", version = "0.4.1" }
 
 [dev-dependencies]
 env_logger = "0.7"
+uuid = { version = "0.8.1", features = ["v4"] }
 
 [features]
 unstable = []

--- a/examples/leader_latch.rs
+++ b/examples/leader_latch.rs
@@ -1,0 +1,36 @@
+extern crate env_logger;
+extern crate uuid;
+extern crate zookeeper;
+
+use std::{sync::Arc, thread, time::Duration};
+use uuid::Uuid;
+use zookeeper::{recipes::leader::LeaderLatch, WatchedEvent, Watcher, ZooKeeper};
+
+const LATCH_PATH: &str = "/latch-ex";
+
+struct NoopWatcher;
+
+impl Watcher for NoopWatcher {
+    fn handle(&self, _ev: WatchedEvent) {}
+}
+
+fn main() {
+    env_logger::init();
+    let zk =
+        ZooKeeper::connect("localhost:2181", Duration::from_millis(2500), NoopWatcher).unwrap();
+
+    let id = Uuid::new_v4().to_string();
+    log::info!("starting host with id: {:?}", id);
+
+    let latch = LeaderLatch::new(Arc::new(zk), id.clone(), LATCH_PATH.into());
+    latch.start().unwrap();
+
+    loop {
+        if latch.has_leadership() {
+            log::info!("{:?} is the leader", id);
+        } else {
+            log::info!("{:?} is a follower", id);
+        }
+        thread::sleep(Duration::from_millis(1000));
+    }
+}

--- a/src/recipes/leader.rs
+++ b/src/recipes/leader.rs
@@ -1,0 +1,249 @@
+use crate::{
+    paths, Acl, CreateMode, Subscription, WatchedEvent, WatchedEventType, ZkError, ZkResult,
+    ZkState, ZooKeeper,
+};
+use std::{
+    cmp, iter,
+    sync::{
+        atomic::{self, AtomicBool, AtomicU8},
+        Arc, Mutex,
+    },
+};
+
+const LATCH_PREFIX: &str = "latch";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum State {
+    Latent = 0,
+    Started = 1,
+    Closed = 2,
+}
+
+impl PartialEq<u8> for State {
+    fn eq(&self, other: &u8) -> bool {
+        *self == State::from(*other)
+    }
+}
+
+impl From<u8> for State {
+    fn from(value: u8) -> Self {
+        match value {
+            0 => State::Latent,
+            1 => State::Started,
+            2 => State::Closed,
+            _ => unreachable!(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ZNode {
+    path: String,
+    seqn: usize,
+}
+
+impl ZNode {
+    pub fn with_parent(parent_path: &str, path: &str) -> Option<Self> {
+        let seqn = path.split('-').last()?.parse().ok()?;
+        Some(Self {
+            path: paths::make_path(parent_path, path),
+            seqn,
+        })
+    }
+
+    pub fn creation_path(parent_path: &str, id: &str) -> String {
+        paths::make_path(parent_path, &format!("{}-{}-", LATCH_PREFIX, id))
+    }
+}
+
+impl Ord for ZNode {
+    fn cmp(&self, other: &Self) -> cmp::Ordering {
+        self.seqn.cmp(&other.seqn)
+    }
+}
+
+impl PartialOrd for ZNode {
+    fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+#[derive(Clone)]
+pub struct LeaderLatch {
+    zk: Arc<ZooKeeper>,
+    id: String,
+    parent_path: String,
+    path: Arc<Mutex<Option<String>>>,
+    state: Arc<AtomicU8>,
+    subscription: Arc<Mutex<Option<Subscription>>>,
+    has_leadership: Arc<AtomicBool>,
+}
+
+impl LeaderLatch {
+    pub fn new(zk: Arc<ZooKeeper>, id: String, parent_path: String) -> Self {
+        Self {
+            zk,
+            id,
+            parent_path,
+            path: Arc::default(),
+            state: Arc::new(AtomicU8::new(State::Latent as u8)),
+            subscription: Arc::default(),
+            has_leadership: Arc::default(),
+        }
+    }
+
+    pub fn start(&self) -> ZkResult<()> {
+        let prev_state = self.set_state(State::Latent, State::Started);
+        if prev_state != State::Latent {
+            panic!("cannot start leader latch in state: {:?}", prev_state);
+        }
+
+        let latch = self.clone();
+        let subscription = self
+            .zk
+            .add_listener(move |x| handle_state_change(&latch, x));
+        *self.subscription.lock().unwrap() = Some(subscription);
+        self.reset()
+    }
+
+    fn reset(&self) -> ZkResult<()> {
+        self.set_leadership(false);
+        self.set_path(None)?;
+
+        let path = create_latch_znode(&self.zk, &self.parent_path, &self.id)?;
+        self.set_path(Some(path))?;
+
+        self.check_leadership()
+    }
+
+    fn check_leadership(&self) -> ZkResult<()> {
+        let znodes = get_latch_znodes(&self.zk, &self.parent_path)?;
+        if let Some(path) = &*self.path.lock().unwrap() {
+            match znodes.iter().position(|znode| &znode.path == path) {
+                Some(0) => {
+                    self.set_leadership(true);
+                }
+                Some(index) => {
+                    let latch = self.clone();
+                    self.zk.exists_w(&znodes[index - 1].path, move |ev| {
+                        handle_znode_change(&latch, ev)
+                    })?;
+                    self.set_leadership(false);
+                }
+                None => {
+                    log::error!("cannot find znode: {:?}", path);
+                    self.reset()?;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    pub fn stop(&self) -> ZkResult<()> {
+        let prev_state = self.set_state(State::Started, State::Closed);
+        if prev_state != State::Started {
+            panic!("cannot close leader latch in state: {:?}", self.state);
+        }
+
+        self.set_path(None)?;
+        self.set_leadership(false);
+
+        let subscription = &mut *self.subscription.lock().unwrap();
+        if let Some(sub) = subscription.take() {
+            self.zk.remove_listener(sub);
+        }
+        Ok(())
+    }
+
+    pub fn id(&self) -> &str {
+        &self.id
+    }
+
+    pub fn path(&self) -> Option<String> {
+        self.path.lock().unwrap().clone()
+    }
+
+    pub fn has_leadership(&self) -> bool {
+        State::Started == self.state.load(atomic::Ordering::SeqCst)
+            && self.has_leadership.load(atomic::Ordering::SeqCst)
+    }
+
+    fn set_leadership(&self, value: bool) {
+        self.has_leadership.store(value, atomic::Ordering::SeqCst);
+    }
+
+    fn set_path(&self, value: Option<String>) -> ZkResult<()> {
+        let path = &mut *self.path.lock().unwrap();
+        if let Some(old_path) = path {
+            match self.zk.delete(old_path, None) {
+                Ok(()) | Err(ZkError::NoNode) => Ok(()),
+                Err(e) => Err(e),
+            }?;
+        }
+        *path = value;
+        Ok(())
+    }
+
+    fn set_state(&self, cur: State, new: State) -> State {
+        State::from(
+            self.state
+                .compare_and_swap(cur as u8, new as u8, atomic::Ordering::SeqCst),
+        )
+    }
+}
+
+fn create_latch_znode(zk: &ZooKeeper, parent_path: &str, id: &str) -> ZkResult<String> {
+    ensure_path(zk, parent_path)?;
+    zk.create(
+        &ZNode::creation_path(parent_path, id),
+        vec![],
+        Acl::open_unsafe().clone(),
+        CreateMode::EphemeralSequential,
+    )
+}
+
+fn get_latch_znodes(zk: &ZooKeeper, parent_path: &str) -> ZkResult<Vec<ZNode>> {
+    let znodes = zk.get_children(&parent_path, false)?;
+    let mut latch_znodes: Vec<_> = znodes
+        .into_iter()
+        .filter_map(|path| ZNode::with_parent(&parent_path, &path))
+        .collect();
+    latch_znodes.sort();
+    Ok(latch_znodes)
+}
+
+fn ensure_path(zk: &ZooKeeper, path: &str) -> ZkResult<()> {
+    for (i, _) in path
+        .chars()
+        .chain(iter::once('/'))
+        .enumerate()
+        .skip(1)
+        .filter(|c| c.1 == '/')
+    {
+        match zk.create(
+            &path[..i],
+            vec![],
+            Acl::open_unsafe().clone(),
+            CreateMode::Container,
+        ) {
+            Ok(_) | Err(ZkError::NodeExists) => {}
+            Err(e) => return Err(e),
+        }
+    }
+    Ok(())
+}
+
+fn handle_znode_change(latch: &LeaderLatch, ev: WatchedEvent) {
+    if let WatchedEventType::NodeDeleted = ev.event_type {
+        if let Err(e) = latch.check_leadership() {
+            log::error!("failed to check for leadership: {:?}", e);
+            latch.set_leadership(false);
+        }
+    }
+}
+
+fn handle_state_change(latch: &LeaderLatch, zk_state: ZkState) {
+    if let ZkState::Closed = zk_state {
+        latch.set_leadership(false);
+    }
+}

--- a/src/recipes/mod.rs
+++ b/src/recipes/mod.rs
@@ -1,2 +1,3 @@
 //! Extended ZooKeeper recipes from [Apache Curator](http://curator.apache.org/).
 pub mod cache;
+pub mod leader;

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -3,10 +3,12 @@
 extern crate log;
 extern crate env_logger;
 extern crate zookeeper;
+extern crate uuid;
 
 mod test_zk;
 mod test_cache;
 mod test_recursive;
+mod test_leader;
 
 use std::io::{BufRead, BufReader, Write};
 use std::process::{Child, Command, Stdio};

--- a/tests/test_leader.rs
+++ b/tests/test_leader.rs
@@ -1,0 +1,70 @@
+use uuid::Uuid;
+use zookeeper::{recipes::leader::LeaderLatch, ZkResult, ZooKeeper};
+
+use env_logger;
+use std::{sync::Arc, time::Duration};
+use ZkCluster;
+
+const LATCH_PATH: &str = "/latch-test";
+
+#[test]
+fn leader_latch_test() -> ZkResult<()> {
+    let _ = env_logger::try_init();
+
+    let cluster = ZkCluster::start(1);
+    let zk = Arc::new(ZooKeeper::connect(
+        &cluster.connect_string,
+        Duration::from_secs(30),
+        |_ev| {},
+    )?);
+
+    let id1 = Uuid::new_v4().to_string();
+    let latch1 = LeaderLatch::new(Arc::clone(&zk), id1, LATCH_PATH.into());
+
+    let id2 = Uuid::new_v4().to_string();
+    let latch2 = LeaderLatch::new(Arc::clone(&zk), id2, LATCH_PATH.into());
+
+    latch1.start().unwrap();
+    assert!(latch1.has_leadership());
+
+    latch2.start().unwrap();
+    assert!(!latch2.has_leadership());
+
+    let latch1_path = latch1.path().unwrap();
+    let latch2_path = latch2.path().unwrap();
+
+    latch1.stop()?;
+    assert!(zk.exists(&latch1_path, false)?.is_none());
+    assert!(zk.exists(&latch2_path, false)?.is_some());
+
+    assert!(!latch1.has_leadership());
+    assert!(latch2.has_leadership());
+
+    latch2.stop()?;
+    assert!(!latch2.has_leadership());
+
+    zk.delete(LATCH_PATH, None)?;
+    Ok(())
+}
+
+#[test]
+fn leader_latch_test_disconnect() -> ZkResult<()> {
+    let _ = env_logger::try_init();
+
+    let cluster = ZkCluster::start(1);
+    let zk = Arc::new(ZooKeeper::connect(
+        &cluster.connect_string,
+        Duration::from_secs(30),
+        |_ev| {},
+    )?);
+
+    let id = Uuid::new_v4().to_string();
+    let latch = LeaderLatch::new(Arc::clone(&zk), id, LATCH_PATH.into());
+
+    latch.start().unwrap();
+    assert!(latch.has_leadership());
+
+    zk.close()?;
+    assert!(!latch.has_leadership());
+    Ok(())
+}


### PR DESCRIPTION
Related to #17 

This PR adds the `LeaderLatch` to `recipes/leader`. It is a port of the Apache Curator `LeaderLatch` implemented [here][curator-leader-latch].

It's certainly not a perfect port and so a few things worth noting:

- I am no expert in Zookeeper, or distributed systems in general, so this could be horribly incorrect (but super keen to get some feedback and code review! :smile:)
- In my very limited understanding of atomics and synchronization I have used `Ordering::SeqCst` as, if I'm not mistaken, [that is how Java synchronizes atomic][concurrency-patterns-java].
- In the Java impl, atomic references are also [used for strings][curator-atomic-ref] but here we just use a `Mutex` (for `path` and `subscription`).
- This impl doesn't (yet) handle when the client reconnects to ZK after it has disconnected. On a disconnect, it will `setLeadership(false)` but on a reconnect [it should][curator-reconnect-reset] call `LeaderLatch::reset`.
- The [ZK docs talk about][zk-guid-error-recovery] using a GUID (the `id` attribute) to help clients recover from errors, specifically when calling `ZooKeeper::create`. This isn't implemented, and given the latch znodes are ephemeral (and sequential) I'm not sure how useful it would be since clients could just `start` a new `LeaderLatch` - so might be something for later.
- Parent znodes should be created with `create_mode=container` but `ZooKeeperExt::ensure_path` hardcodes the `create_mode` as `persistent`. I've just copied that `ensure_path` into `recipes/leader`, but might be nice to consolidate the two impls.

I've also added some (very rough) tests and an example to demonstrate a leader being elected and, when the leader is killed, a follower becoming the new leader.

This recipe definitely needs more tests, probably an explanation of the example, and more comprehensive logging and documentation (maybe part of #15 too) but wanted to put this up to start getting some feedback. And if it's merged before some of these improvements are in, I'm happy to follow up with some more PRs :+1: 

Thanks! :tada: 

[curator-leader-latch]: https://github.com/apache/curator/blob/master/curator-recipes/src/main/java/org/apache/curator/framework/recipes/leader/LeaderLatch.java
[curator-reconnect-reset]: https://github.com/apache/curator/blob/master/curator-recipes/src/main/java/org/apache/curator/framework/recipes/leader/LeaderLatch.java#L649
[curator-atomic-ref]: https://github.com/apache/curator/blob/master/curator-recipes/src/main/java/org/apache/curator/framework/recipes/leader/LeaderLatch.java#L72
[zk-guid-error-recovery]: https://zookeeper.apache.org/doc/current/recipes.html#sc_recipes_GuidNote
[concurrency-patterns-java]: https://medium.com/@sharplermc/concurrency-patterns-in-rust-from-java-58aa15e5f17b