### PR TITLE
Update curator-test dependency

### DIFF
--- a/zk-test-cluster/pom.xml
+++ b/zk-test-cluster/pom.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>org.apache.curator</groupId>
             <artifactId>curator-test</artifactId>
-            <version>2.9.0</version>
+            <version>5.0.0</version>
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>


### PR DESCRIPTION
This PR upgrades the `curator-test` dependency for the `zk-test-cluster`. This is required for #69 which relies on container znodes introduced only after version 3.6.0 - see [here](https://zookeeper.apache.org/doc/current/zookeeperProgrammers.html#Container+Nodes)