### PR TITLE
Track is_connected for ZooKeeper

### DIFF
--- a/tests/test_cache.rs
+++ b/tests/test_cache.rs
@@ -6,13 +6,9 @@ use ZkCluster;
 
 use std::sync::Arc;
 use std::time::Duration;
-use env_logger;
-
 
 #[test]
 fn path_children_cache_test() {
-    let _ = env_logger::try_init();
-
     // Create a test cluster
     let cluster = ZkCluster::start(1);
 
@@ -31,5 +27,5 @@ fn path_children_cache_test() {
 
     let data = path_children_cache.get_current_data();
 
-    info!("Data: {:?}", data);
+    println!("Data: {:?}", data);
 }


### PR DESCRIPTION
This PR adds `ZooKeeper::is_connected` to track if there is still an open connection. This is used to prevent re-closing the connection on `ZooKeeper::drop` if it already closed.

An alternative could be to pattern match on the error returned in `ZooKeeper::drop`, and ignore if it is `ZkError::ConnectionLoss` but IMHO this is a better approach as it doesn't involve going through the motions of trying to send requests to the ZK cluster. Happy to discuss though if there is a different preference :slightly_smiling_face: 