### PR TITLE
Fix lock not setting handler on first node

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zookeeper"
-version = "0.5.9"
+version = "0.5.10"
 authors = ["Nandor Kracser <bonifaido@gmail.com>"]
 license = "MIT"
 homepage = "https://github.com/bonifaido/rust-zookeeper"

--- a/src/recipes/leader.rs
+++ b/src/recipes/leader.rs
@@ -202,7 +202,7 @@ fn create_latch_znode(ll: &LeaderLatch, parent_path: &str, id: &str) -> ZkResult
     )?;
     // add the handle_znode_change to the freshly created znode
     let latch = ll.clone();
-    ll.zk.exists_w(&ZNode::creation_path(parent_path, id), move |ev| {
+    ll.zk.exists_w(&zrsp, move |ev| {
         handle_znode_change(&latch, ev)
     })?;
     Ok(zrsp)
@@ -240,6 +240,7 @@ fn ensure_path(zk: &ZooKeeper, path: &str) -> ZkResult<()> {
 }
 
 fn handle_znode_change(latch: &LeaderLatch, ev: WatchedEvent) {
+    debug!("got znode change event");
     if let WatchedEventType::NodeDeleted = ev.event_type {
         if let Err(e) = latch.check_leadership() {
             log::error!("failed to check for leadership: {:?}", e);

--- a/src/recipes/leader.rs
+++ b/src/recipes/leader.rs
@@ -110,7 +110,7 @@ impl LeaderLatch {
         self.set_leadership(false);
         self.set_path(None)?;
 
-        let path = create_latch_znode(&self.zk, &self.parent_path, &self.id)?;
+        let path = create_latch_znode(self, &self.parent_path, &self.id)?;
         self.set_path(Some(path))?;
 
         self.check_leadership()
@@ -192,14 +192,20 @@ impl LeaderLatch {
     }
 }
 
-fn create_latch_znode(zk: &ZooKeeper, parent_path: &str, id: &str) -> ZkResult<String> {
-    ensure_path(zk, parent_path)?;
-    zk.create(
+fn create_latch_znode(ll: &LeaderLatch, parent_path: &str, id: &str) -> ZkResult<String> {
+    ensure_path(&ll.zk, parent_path)?;
+    let zrsp = ll.zk.create(
         &ZNode::creation_path(parent_path, id),
         vec![],
         Acl::open_unsafe().clone(),
         CreateMode::EphemeralSequential,
-    )
+    )?;
+    // add the handle_znode_change to the freshly created znode
+    let latch = ll.clone();
+    ll.zk.exists_w(&ZNode::creation_path(parent_path, id), move |ev| {
+        handle_znode_change(&latch, ev)
+    })?;
+    Ok(zrsp)
 }
 
 fn get_latch_znodes(zk: &ZooKeeper, parent_path: &str) -> ZkResult<Vec<ZNode>> {

--- a/src/recipes/leader.rs
+++ b/src/recipes/leader.rs
@@ -240,7 +240,6 @@ fn ensure_path(zk: &ZooKeeper, path: &str) -> ZkResult<()> {
 }
 
 fn handle_znode_change(latch: &LeaderLatch, ev: WatchedEvent) {
-    debug!("got znode change event");
     if let WatchedEventType::NodeDeleted = ev.event_type {
         if let Err(e) = latch.check_leadership() {
             log::error!("failed to check for leadership: {:?}", e);


### PR DESCRIPTION
I noticed that the first node started never adds the event handler to the znode. So, if the znode is deleted the first lock holder will never see that event which could lead two 2 clients holding the lock- one holding it and another thinking it holds it.