### PR TITLE
change connect log messages from info to trace level

### DIFF
--- a/src/io.rs
+++ b/src/io.rs
@@ -236,7 +236,7 @@ impl ZkIo {
                 self.state = ZkState::NotConnected;
             } else {
                 self.conn_resp = conn_resp;
-                info!("Connected: {:?}", self.conn_resp);
+                trace!("Connected: {:?}", self.conn_resp);
                 self.timeout_ms = self.conn_resp.timeout;
                 self.ping_timeout_duration = Duration::from_millis(self.conn_resp.timeout / 3 * 2);
 


### PR DESCRIPTION
Currently info level log messages are displayed when connections
are established, it would be better to have these as trace level
especially when considering the actual log message.

Changes the log macro from info to trace to reflect the desired log
level for these messages.

Logging output is now quieter.