### PR TITLE
Avoid leaking watch threads on client shutdown

### DIFF
--- a/src/watch.rs
+++ b/src/watch.rs
@@ -63,26 +63,21 @@ pub struct ZkWatch<W: Watcher> {
     watcher: W,
     watches: HashMap<String, Vec<Watch>>,
     chroot: Option<String>,
-    tx: Sender<WatchMessage>,
     rx: Receiver<WatchMessage>,
 }
 
 impl<W: Watcher> ZkWatch<W> {
-    pub fn new(watcher: W, chroot: Option<String>) -> Self {
+    pub fn new(watcher: W, chroot: Option<String>) -> (Self, Sender<WatchMessage>) {
         trace!("ZkWatch::new");
         let (tx, rx) = mpsc::channel();
 
-        ZkWatch {
+        let watch = ZkWatch {
             watches: HashMap::new(),
             watcher: watcher,
             chroot: chroot,
-            tx,
             rx
-        }
-    }
-
-    pub fn sender(&self) -> Sender<WatchMessage> {
-        self.tx.clone()
+        };
+        (watch, tx)
     }
 
     pub fn run(mut self) -> io::Result<()> {

--- a/src/zookeeper.rs
+++ b/src/zookeeper.rs
@@ -68,10 +68,10 @@ impl ZooKeeper {
 
         debug!("Initiating connection to {}", connect_string);
 
-        let watch = ZkWatch::new(watcher, chroot.clone());
+        let (watch, watch_sender) = ZkWatch::new(watcher, chroot.clone());
         let listeners = ListenerSet::<ZkState>::new();
         let listeners1 = listeners.clone();
-        let io = ZkIo::new(addrs.clone(), timeout, watch.sender(), listeners1);
+        let io = ZkIo::new(addrs.clone(), timeout, watch_sender, listeners1);
         let sender = io.sender();
 
         try!(Self::zk_thread("event", move || watch.run().unwrap()));


### PR DESCRIPTION
When creating the ZkWatch struct, we keep a reference to the sender of the channel and clone it on `sender()` to pass along to the `ZkIo` struct.

When the ZkIo thread finishes, its copy of the sender is dropped but the channel is not closed because the watch has a reference to its own sender, therefore leaking the thread.

Instead, we can prevent the watch from ever taking the sender by returning it through the constructor, so that it can be owned by `ZkIo` which will close the channel as expected on shutdown.