### PR TITLE
Introduce persistent watches

### DIFF
--- a/examples/persistent_watches.rs
+++ b/examples/persistent_watches.rs
@@ -1,0 +1,135 @@
+#![deny(unused_mut)]
+extern crate zookeeper;
+#[macro_use]
+extern crate log;
+extern crate env_logger;
+
+use std::env;
+use std::io;
+use std::io::BufRead;
+use std::time::Duration;
+use zookeeper::AddWatchMode;
+use zookeeper::WatcherType;
+use zookeeper::ZooKeeperExt;
+use zookeeper::{Acl, CreateMode, WatchedEvent, Watcher, ZooKeeper};
+
+struct LoggingWatcher;
+impl Watcher for LoggingWatcher {
+    fn handle(&self, e: WatchedEvent) {
+        info!("{:?}", e)
+    }
+}
+
+fn zk_server_urls() -> String {
+    let key = "ZOOKEEPER_SERVERS";
+    match env::var(key) {
+        Ok(val) => val,
+        Err(_) => "localhost:2181".to_string(),
+    }
+}
+
+fn zk_example() {
+    let zk_urls = zk_server_urls();
+    println!("connecting to {}", zk_urls);
+
+    let root = format!("/example-{}", uuid::Uuid::new_v4());
+    let modifying_zk =
+        ZooKeeper::connect(&*zk_urls, Duration::from_secs(15), LoggingWatcher).unwrap();
+    let recursive_watch_zk =
+        ZooKeeper::connect(&*zk_urls, Duration::from_secs(15), LoggingWatcher).unwrap();
+    let persistent_watch_zk =
+        ZooKeeper::connect(&*zk_urls, Duration::from_secs(15), LoggingWatcher).unwrap();
+
+    // Creating separate clients to show the example where modifications to the nodes
+    // take place in a different session than our own.
+    modifying_zk.add_listener(|zk_state| println!("New modifying ZkState is {:?}", zk_state));
+
+    // Also separate clients per type of watch as there is a bug when creating multiple type watchers in the same
+    // path in the same session
+    // https://issues.apache.org/jira/browse/ZOOKEEPER-4466
+    recursive_watch_zk.add_listener(|zk_state| println!("New recursive watch ZkState is {:?}", zk_state));
+    persistent_watch_zk.add_listener(|zk_state| println!("New peristent watch ZkState is {:?}", zk_state));
+
+    modifying_zk.ensure_path(&root).unwrap();
+
+    recursive_watch_zk
+        .add_watch(&root, AddWatchMode::PersistentRecursive, |event| {
+            println!("received persistent recursive watch event {event:?}");
+        })
+        .unwrap();
+
+    persistent_watch_zk
+        .add_watch(&root, AddWatchMode::Persistent, |event| {
+            println!("received persistent watch event {event:?}");
+        })
+        .unwrap();
+
+    println!("press c to add and modify child, e to edit the watched node, anything else to proceed");
+    let stdin = io::stdin();
+    let inputs = stdin.lock().lines();
+    let mut incr = 0;
+    for input in inputs {
+        incr += 1;
+        match input.unwrap().as_str() {
+            "c" => {
+                let child_path = format!("{root}/child-{incr}");
+                modifying_zk
+                    .create(
+                        &child_path,
+                        b"".to_vec(),
+                        Acl::open_unsafe().clone(),
+                        CreateMode::Ephemeral,
+                    )
+                    .unwrap();
+                modifying_zk
+                    .set_data(
+                        &child_path,
+                        b"new-data".to_vec(),
+                        None,
+                    )
+                    .unwrap();
+                modifying_zk
+                    .delete(&child_path, None)
+                    .unwrap();
+            },
+            "e" => {
+                modifying_zk
+                    .set_data(
+                        &root,
+                        format!("new-data-{incr}").into_bytes(),
+                        None,
+                    )
+                    .unwrap();
+            }
+            other => {
+                println!("received {other}");
+                break
+            }
+        }
+    }
+
+    println!("removing watch");
+    recursive_watch_zk
+        .remove_watches(&root, WatcherType::Any)
+        .unwrap();
+    persistent_watch_zk
+        .remove_watches(&root, WatcherType::Any)
+        .unwrap();
+
+    println!("creating child node. This shouldn't have a new event");
+    modifying_zk
+        .create(
+            &format!("{root}/child-no-notification"),
+            b"".to_vec(),
+            Acl::open_unsafe().clone(),
+            CreateMode::Ephemeral,
+        )
+        .unwrap();
+
+    modifying_zk.delete_recursive(&root).unwrap();
+}
+
+fn main() {
+    env_logger::init();
+    zk_example();
+}

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -113,7 +113,7 @@ pub enum KeeperState {
 }
 
 /// Enumeration of types of events that may occur on the znode.
-#[derive(Clone, Copy, Debug, EnumConvertFromInt)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, EnumConvertFromInt)]
 pub enum WatchedEventType {
     /// Nothing known has occurred on the znode. This value is issued as part of a `WatchedEvent`
     /// when the `KeeperState` changes.
@@ -133,6 +133,48 @@ pub enum WatchedEventType {
     DataWatchRemoved = 5,
     /// Issued when the client removes a child watcher.
     ChildWatchRemoved = 6
+}
+
+/// The mode of watch.
+#[derive(Clone, Copy, Debug, EnumConvertFromInt)]
+pub enum AddWatchMode {
+    /// Set a watcher on the given path that does not get removed when triggered (i.e. it stays active
+    /// until it is removed). This watcher
+    /// is triggered for both data and child events. To remove the watcher, use
+    /// remove_watches. The watcher behaves as if you placed an exists() watch and
+    /// a get_data() watch on the ZNode at the given path.
+    /// Requires Zookeeper 3.6.0
+    Persistent = 0,
+    /// Like a Persistent watcher but applies not only to the registered path but all child
+    /// paths recursively. This watcher is triggered for both data and child events.
+    /// To remove the watcher, use remove_watches().
+    /// Requires Zookeeper 3.6.0
+    PersistentRecursive = 1,
+}
+
+/// The type of watcher.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, EnumConvertFromInt)]
+pub enum WatcherType {
+    Children = 1,
+    Data = 2,
+    Any = 3,
+    Persistent = 4,
+    PersistentRecursive = 5,
+}
+
+impl From<AddWatchMode> for WatcherType {
+    fn from(watch_mode: AddWatchMode) -> Self {
+        match watch_mode {
+            AddWatchMode::Persistent => Self::Persistent,
+            AddWatchMode::PersistentRecursive => Self::PersistentRecursive,
+        }
+    }
+}
+
+impl WatcherType {
+    pub fn is_persistent(&self) -> bool {
+        self == &Self::Persistent || self == &Self::PersistentRecursive
+    }
 }
 
 /// Enumeration of states the client may be at any time.

--- a/src/io.rs
+++ b/src/io.rs
@@ -1,23 +1,24 @@
 use consts::{ZkError, ZkState};
-use proto::{ByteBuf, ConnectRequest, ConnectResponse, OpCode, ReadFrom, ReplyHeader, RequestHeader,
-            WriteTo};
-use watch::WatchMessage;
-use zookeeper::{RawResponse, RawRequest};
 use listeners::ListenerSet;
+use proto::{
+    ByteBuf, ConnectRequest, ConnectResponse, OpCode, ReadFrom, ReplyHeader, RequestHeader, WriteTo,
+};
+use watch::WatchMessage;
+use zookeeper::{RawRequest, RawResponse};
 
 use byteorder::{BigEndian, ByteOrder};
 use bytes::{Buf, Bytes, BytesMut};
 use mio::net::TcpStream;
 use mio::*;
-use mio_extras::channel::{Sender, Receiver, channel};
-use mio_extras::timer::{Timer, Timeout};
+use mio_extras::channel::{channel, Receiver, Sender};
+use mio_extras::timer::{Timeout, Timer};
 use std::collections::VecDeque;
 use std::io;
 use std::io::{Cursor, ErrorKind};
-use std::net::SocketAddr;
-use std::time::{Duration, Instant};
-use std::sync::mpsc;
 use std::mem;
+use std::net::SocketAddr;
+use std::sync::mpsc;
+use std::time::{Duration, Instant};
 
 const ZK: Token = Token(1);
 const TIMER: Token = Token(2);
@@ -26,8 +27,12 @@ const CHANNEL: Token = Token(3);
 use try_io::{TryRead, TryWrite};
 
 lazy_static! {
-    static ref PING: ByteBuf =
-    RequestHeader{xid: -2, opcode: OpCode::Ping}.to_len_prefixed_buf().unwrap();
+    static ref PING: ByteBuf = RequestHeader {
+        xid: -2,
+        opcode: OpCode::Ping
+    }
+    .to_len_prefixed_buf()
+    .unwrap();
 }
 
 struct Hosts {
@@ -94,11 +99,11 @@ impl ZkIo {
         addrs: Vec<SocketAddr>,
         ping_timeout_duration: Duration,
         watch_sender: mpsc::Sender<WatchMessage>,
-        state_listeners: ListenerSet<ZkState>
+        state_listeners: ListenerSet<ZkState>,
     ) -> ZkIo {
         trace!("ZkIo::new");
-        let timeout_ms = ping_timeout_duration.as_secs() * 1000 +
-            ping_timeout_duration.subsec_nanos() as u64 / 1000000;
+        let timeout_ms = ping_timeout_duration.as_secs() * 1000
+            + ping_timeout_duration.subsec_nanos() as u64 / 1000000;
         let (tx, rx) = channel();
 
         let mut zkio = ZkIo {
@@ -154,7 +159,11 @@ impl ZkIo {
 
             let len = BigEndian::read_i32(&self.response[..4]) as usize;
 
-            trace!("Response chunk len = {} buf len is {}", len, self.response.len());
+            trace!(
+                "Response chunk len = {} buf len is {}",
+                len,
+                self.response.len()
+            );
 
             if self.response.len() - 4 < len {
                 return;
@@ -194,27 +203,26 @@ impl ZkIo {
             match response.header.xid {
                 -1 => {
                     trace!("handle_response Got a watch event!");
-                    self.watch_sender.send(WatchMessage::Event(response)).unwrap();
+                    self.watch_sender
+                        .send(WatchMessage::Event(response))
+                        .unwrap();
                 }
                 -2 => {
-                    trace!("Got ping response in {:?}",
-                           self.ping_sent.elapsed());
+                    trace!("Got ping response in {:?}", self.ping_sent.elapsed());
                     self.inflight.pop_front();
                 }
-                _ => {
-                    match self.inflight.pop_front() {
-                        Some(request) => {
-                            if request.opcode == OpCode::CloseSession {
-                                let old_state = self.state;
-                                self.state = ZkState::Closed;
-                                self.notify_state(old_state, self.state);
-                                self.shutdown = true;
-                            }
-                            self.send_response(request, response);
+                _ => match self.inflight.pop_front() {
+                    Some(request) => {
+                        if request.opcode == OpCode::CloseSession {
+                            let old_state = self.state;
+                            self.state = ZkState::Closed;
+                            self.notify_state(old_state, self.state);
+                            self.shutdown = true;
                         }
-                        None => panic!("Shouldn't happen, no inflight request"),
+                        self.send_response(request, response);
                     }
-                }
+                    None => panic!("Shouldn't happen, no inflight request"),
+                },
             }
         } else {
             self.inflight.pop_front(); // drop the connect request
@@ -259,19 +267,20 @@ impl ZkIo {
             }
             None => info!("Nobody is interested in response {:?}", request.opcode),
         }
-        if let Some(watch) = request.watch {
-            self.watch_sender.send(WatchMessage::Watch(watch)).unwrap();
+        match (request.opcode, request.watch) {
+            (OpCode::RemoveWatches, Some(w)) => self
+                .watch_sender
+                .send(WatchMessage::RemoveWatch(w.path, w.watcher_type))
+                .unwrap(),
+            (_, Some(w)) => self.watch_sender.send(WatchMessage::Watch(w)).unwrap(),
+            (_, None) => {},
         }
     }
 
     fn clear_timeout(&mut self, atype: ZkTimeout) {
         let timeout = match atype {
-            ZkTimeout::Ping => {
-                mem::replace(&mut self.ping_timeout , None)
-            },
-            ZkTimeout::Connect => {
-                mem::replace(&mut self.conn_timeout , None)
-            },
+            ZkTimeout::Ping => mem::replace(&mut self.ping_timeout, None),
+            ZkTimeout::Connect => mem::replace(&mut self.conn_timeout, None),
         };
         if let Some(timeout) = timeout {
             trace!("clear_timeout: {:?}", atype);
@@ -286,13 +295,14 @@ impl ZkIo {
             ZkTimeout::Ping => {
                 let duration = self.ping_timeout_duration.clone();
                 self.ping_timeout = Some(self.timer.set_timeout(duration, atype));
-            },
+            }
             ZkTimeout::Connect => {
                 let duration = self.conn_timeout_duration.clone();
                 self.conn_timeout = Some(self.timer.set_timeout(duration, atype));
-            },
+            }
         }
-        self.poll.reregister(&self.timer, TIMER, Ready::readable(), pollopt())
+        self.poll
+            .reregister(&self.timer, TIMER, Ready::readable(), pollopt())
             .expect("Reregister TIMER");
     }
 
@@ -338,10 +348,10 @@ impl ZkIo {
             let request = self.connect_request();
             self.buffer.push_back(request);
 
-
             // Register the new socket
             let pollopt = PollOpt::edge() | PollOpt::oneshot();
-            self.poll.register(&self.sock, ZK, Ready::all(), pollopt)
+            self.poll
+                .register(&self.sock, ZK, Ready::all(), pollopt)
                 .expect("Register ZK");
 
             break;
@@ -391,16 +401,16 @@ impl ZkIo {
                         }
                     }
                     Ok(None) => trace!("Spurious write"),
-                    Err(e) => {
-                        match e.kind() {
-                            ErrorKind::WouldBlock => trace!("Got WouldBlock IO Error, no need to reconnect."),
-                            _ => {
-                                error!("Failed to write socket: {:?}", e);
-                                self.reconnect();
-                                return;
-                            }
+                    Err(e) => match e.kind() {
+                        ErrorKind::WouldBlock => {
+                            trace!("Got WouldBlock IO Error, no need to reconnect.")
                         }
-                    }
+                        _ => {
+                            error!("Failed to write socket: {:?}", e);
+                            self.reconnect();
+                            return;
+                        }
+                    },
                 }
             }
         }
@@ -417,18 +427,17 @@ impl ZkIo {
                     self.handle_response();
                 }
                 Ok(None) => trace!("Spurious read"),
-                Err(e) => {
-                    match e.kind() {
-                        ErrorKind::WouldBlock => trace!("Got WouldBlock IO Error, no need to reconnect."),
-                        _ => {
-                            error!("Failed to read socket: {:?}", e);
-                            self.reconnect();
-                            return;
-                        }
+                Err(e) => match e.kind() {
+                    ErrorKind::WouldBlock => {
+                        trace!("Got WouldBlock IO Error, no need to reconnect.")
                     }
-                }
+                    _ => {
+                        error!("Failed to read socket: {:?}", e);
+                        self.reconnect();
+                        return;
+                    }
+                },
             }
-
         }
 
         if (ready.is_hup()) && (self.state != ZkState::Closed) {
@@ -485,18 +494,19 @@ impl ZkIo {
                         data: ByteBuf::new(vec![]),
                     };
                     self.send_response(request, response);
-                },
+                }
                 _ => {
                     // Otherwise, queue request for processing.
                     if self.buffer.is_empty() {
                         self.reregister(Ready::all());
                     }
                     self.buffer.push_back(request);
-                },
+                }
             }
         }
 
-        self.poll.reregister(&self.rx, CHANNEL, Ready::readable(), pollopt())
+        self.poll
+            .reregister(&self.rx, CHANNEL, Ready::readable(), pollopt())
             .expect("Reregister CHANNEL");
     }
 
@@ -511,15 +521,17 @@ impl ZkIo {
                     if self.inflight.is_empty() {
                         // No inflight request indicates an idle connection. Send a ping.
                         trace!("Pinging {:?}", self.sock.peer_addr().unwrap());
-                        self.tx.send(RawRequest {
-                            opcode: OpCode::Ping,
-                            data: PING.clone(),
-                            listener: None,
-                            watch: None,
-                        }).unwrap();
+                        self.tx
+                            .send(RawRequest {
+                                opcode: OpCode::Ping,
+                                data: PING.clone(),
+                                listener: None,
+                                watch: None,
+                            })
+                            .unwrap();
                         self.ping_sent = Instant::now();
                     }
-                },
+                }
                 Some(ZkTimeout::Connect) => {
                     trace!("handle connection timeout");
                     self.clear_timeout(ZkTimeout::Connect);
@@ -527,11 +539,12 @@ impl ZkIo {
                         info!("Reconnect due to connection timeout");
                         self.reconnect();
                     }
-                },
+                }
                 None => {
                     if self.ping_timeout.is_some() || self.conn_timeout.is_some() {
                         trace!("Spurious timer");
-                        self.poll.reregister(&self.timer, TIMER, Ready::readable(), pollopt())
+                        self.poll
+                            .reregister(&self.timer, TIMER, Ready::readable(), pollopt())
                             .expect("Reregister TIMER");
                     }
                     break;
@@ -548,11 +561,14 @@ impl ZkIo {
         let mut events = Events::with_capacity(128);
 
         // Register Initial Interest
-        self.poll.register(&self.sock, ZK, Ready::all(), pollopt())
+        self.poll
+            .register(&self.sock, ZK, Ready::all(), pollopt())
             .expect("Register ZK");
-        self.poll.register(&self.timer, TIMER, Ready::readable(), pollopt())
+        self.poll
+            .register(&self.timer, TIMER, Ready::readable(), pollopt())
             .expect("Register TIMER");
-        self.poll.register(&self.rx, CHANNEL, Ready::readable(), pollopt())
+        self.poll
+            .register(&self.rx, CHANNEL, Ready::readable(), pollopt())
             .expect("Register CHANNEL");
 
         loop {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,11 +13,11 @@ extern crate snowflake;
 extern crate zookeeper_derive;
 
 pub use acl::*;
-pub use consts::*;
+pub use consts::{*, WatcherType};
 pub use data::*;
 pub use zookeeper::{ZkResult, ZooKeeper};
 pub use zookeeper_ext::ZooKeeperExt;
-pub use watch::{Watch, WatchedEvent, Watcher, WatchType};
+pub use watch::{Watch, WatchedEvent, Watcher};
 
 pub use listeners::Subscription;
 

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -1,10 +1,20 @@
 use consts::{KeeperState, WatchedEventType};
-use consts::WatchedEventType::{NodeCreated, NodeDataChanged, NodeDeleted, NodeChildrenChanged};
+use consts::{
+    WatchedEventType::{NodeChildrenChanged, NodeCreated, NodeDataChanged, NodeDeleted},
+    WatcherType,
+};
 use proto::ReadFrom;
-use zookeeper::RawResponse;
-use std::sync::mpsc::{self, Sender, Receiver};
 use std::collections::HashMap;
 use std::io;
+use std::sync::mpsc::{self, Receiver, Sender};
+use zookeeper::RawResponse;
+
+const PERSISTENT_WATCH_TRIGGERS: [WatchedEventType; 4] = [
+    NodeChildrenChanged,
+    NodeCreated,
+    NodeDataChanged,
+    NodeDeleted,
+];
 
 /// Represents a change on the ZooKeeper that a `Watcher` is able to respond to.
 ///
@@ -20,23 +30,12 @@ pub struct WatchedEvent {
     pub path: Option<String>,
 }
 
-/// Describes what a `Watch` is looking for.
-#[derive(PartialEq)]
-pub enum WatchType {
-    /// Watching for changes to children.
-    Child,
-    /// Watching for changes to data.
-    Data,
-    /// Watching for the creation of a node at the given path.
-    Exist,
-}
-
 /// An object watching a path for certain changes.
 pub struct Watch {
     /// The path to the znode this is watching.
     pub path: String,
     /// The type of changes this watch is looking for.
-    pub watch_type: WatchType,
+    pub watcher_type: WatcherType,
     /// The handler for this watch, to call when it is triggered.
     pub watcher: Box<dyn Watcher>,
 }
@@ -47,7 +46,9 @@ pub trait Watcher: Send {
     fn handle(&self, event: WatchedEvent);
 }
 
-impl<F> Watcher for F where F: Fn(WatchedEvent) + Send
+impl<F> Watcher for F
+where
+    F: Fn(WatchedEvent) + Send,
 {
     fn handle(&self, event: WatchedEvent) {
         self(event)
@@ -57,11 +58,16 @@ impl<F> Watcher for F where F: Fn(WatchedEvent) + Send
 pub enum WatchMessage {
     Event(RawResponse),
     Watch(Watch),
+    RemoveWatch(String, WatcherType),
 }
 
 pub struct ZkWatch<W: Watcher> {
     watcher: W,
     watches: HashMap<String, Vec<Watch>>,
+    // Storing peristent watches separately since they may require splitting the event path
+    // which will have a performance impact. This replicates how they are stored in Zookeeper as well
+    // and allows us to skip removing them from the hashmap and re-adding them.
+    persistent_watches: HashMap<String, Vec<Watch>>,
     chroot: Option<String>,
     rx: Receiver<WatchMessage>,
 }
@@ -73,9 +79,10 @@ impl<W: Watcher> ZkWatch<W> {
 
         let watch = ZkWatch {
             watches: HashMap::new(),
+            persistent_watches: HashMap::new(),
             watcher: watcher,
             chroot: chroot,
-            rx
+            rx,
         };
         (watch, tx)
     }
@@ -94,20 +101,30 @@ impl<W: Watcher> ZkWatch<W> {
                 info!("Event thread got response {:?}", response.header);
                 let mut data = response.data;
                 match response.header.err {
-                    0 => {
-                        match WatchedEvent::read_from(&mut data) {
-                            Ok(mut event) => {
-                                self.cut_chroot(&mut event);
-                                self.dispatch(&event);
-                            }
-                            Err(e) => error!("Failed to parse WatchedEvent {:?}", e),
+                    0 => match WatchedEvent::read_from(&mut data) {
+                        Ok(mut event) => {
+                            self.cut_chroot(&mut event);
+                            self.dispatch(&event);
                         }
-                    }
+                        Err(e) => error!("Failed to parse WatchedEvent {:?}", e),
+                    },
                     e => error!("WatchedEvent.error {:?}", e),
                 }
             }
             WatchMessage::Watch(watch) => {
-                self.watches.entry(watch.path.clone()).or_insert(vec![]).push(watch);
+                let group = if watch.watcher_type.is_persistent() {
+                    &mut self.persistent_watches
+                } else {
+                    &mut self.watches
+                };
+                group
+                    .entry(watch.path.clone())
+                    .or_insert_with(|| vec![])
+                    .push(watch);
+            }
+            WatchMessage::RemoveWatch(path, watcher_type) => {
+                remove_matching_watches(&path, watcher_type, &mut self.watches);
+                remove_matching_watches(&path, watcher_type, &mut self.persistent_watches);
             }
         }
     }
@@ -122,45 +139,86 @@ impl<W: Watcher> ZkWatch<W> {
 
     fn dispatch(&mut self, event: &WatchedEvent) {
         debug!("{:?}", event);
-        if let Some(watches) = self.find_watches(&event) {
-            for watch in watches.into_iter() {
-                watch.watcher.handle(event.clone())
-            }
-        } else {
+        if !self.trigger_watches(&event) {
             self.watcher.handle(event.clone())
         }
     }
 
-    fn find_watches(&mut self, event: &WatchedEvent) -> Option<Vec<Watch>> {
+    /// Triggers all the watches that we have registered, removing the ones that are not persistent.
+    /// Returns whether or not any of the watches fired.
+    fn trigger_watches(&mut self, event: &WatchedEvent) -> bool {
         if let Some(ref path) = event.path {
-            match self.watches.remove(path) {
+            // We execute this in two steps. Once for the one-off watches, and once for the persistent ones.
+            let triggered_watch = match self.watches.remove(path) {
                 Some(watches) => {
-
-                    let (matching, left): (_, Vec<Watch>) = watches.into_iter().partition(|w| {
-                        match event.event_type {
-                            NodeChildrenChanged => w.watch_type == WatchType::Child,
-                            NodeCreated | NodeDataChanged => {
-                                w.watch_type == WatchType::Data || w.watch_type == WatchType::Exist
+                    let (matching, left): (_, Vec<Watch>) =
+                        watches.into_iter().partition(|w| {
+                            match (event.event_type, w.watcher_type) {
+                                (NodeChildrenChanged, WatcherType::Children) => true,
+                                (NodeCreated | NodeDataChanged, WatcherType::Data) => true,
+                                (NodeDeleted, _) => true,
+                                _ => false,
                             }
-                            NodeDeleted => true,
-                            _ => false,
-                        }
-                    });
-
+                        });
                     // put back the remaining watches
                     if !left.is_empty() {
                         self.watches.insert(path.to_owned(), left);
                     }
-                    if matching.is_empty() {
-                        None
-                    } else {
-                        Some(matching)
+                    // Trigger all matching watches.
+                    matching
+                        .iter()
+                        .for_each(|w| w.watcher.handle(event.clone()));
+                    !matching.is_empty()
+                }
+                None => false,
+            };
+
+            let triggered_peristent_watch = if PERSISTENT_WATCH_TRIGGERS.contains(&event.event_type)
+                && !self.persistent_watches.is_empty()
+            {
+                let mut watch_path = String::from("");
+                let mut parts = path.split("/").skip(1);
+                let mut triggered = false;
+                while let Some(part) = parts.next() {
+                    watch_path = watch_path + "/" + part;
+                    if let Some(watches) = self.persistent_watches.get(&watch_path) {
+                        for w in watches {
+                            if match w.watcher_type {
+                                WatcherType::Persistent => path == &watch_path,
+                                WatcherType::PersistentRecursive => true,
+                                _ => false,
+                            } {
+                                w.watcher.handle(event.clone());
+                                triggered = true;
+                            }
+                        }
                     }
                 }
-                None => None,
-            }
+                triggered
+            } else {
+                false
+            };
+            triggered_watch || triggered_peristent_watch
         } else {
-            None
+            false
+        }
+    }
+}
+
+fn remove_matching_watches(
+    path: &str,
+    watcher_type: WatcherType,
+    watches: &mut HashMap<String, Vec<Watch>>,
+) {
+    let remaining_watches: Option<Vec<_>> = watches.remove(path).map(|watches| {
+        watches
+            .into_iter()
+            .filter(|w| w.watcher_type == watcher_type || watcher_type == WatcherType::Any)
+            .collect()
+    });
+    if let Some(w) = remaining_watches {
+        if !w.is_empty() {
+            watches.insert(path.into(), w);
         }
     }
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -9,6 +9,7 @@ mod test_zk;
 mod test_cache;
 mod test_recursive;
 mod test_leader;
+mod test_persistent_recursive_watch;
 
 use std::io::{BufRead, BufReader, Write};
 use std::process::{Child, Command, Stdio};

--- a/tests/test_persistent_recursive_watch.rs
+++ b/tests/test_persistent_recursive_watch.rs
@@ -1,0 +1,146 @@
+use zookeeper::{AddWatchMode, Acl, CreateMode, WatcherType};
+use zookeeper::{WatchedEvent, ZooKeeper, ZooKeeperExt};
+
+use ZkCluster;
+
+use env_logger;
+use std::sync::mpsc;
+use std::time::Duration;
+
+#[test]
+fn persistent_watch_receives_more_than_one_message_on_modifications() {
+    let _ = env_logger::try_init();
+
+    // Create a test cluster
+    let cluster = ZkCluster::start(1);
+
+    let zk_watcher = ZooKeeper::connect(
+        &cluster.connect_string,
+        Duration::from_secs(30),
+        |event: WatchedEvent| info!("{:?}", event),
+    )
+    .unwrap();
+
+    let zk_modifier = ZooKeeper::connect(
+        &cluster.connect_string,
+        Duration::from_secs(30),
+        |event: WatchedEvent| info!("{:?}", event),
+    )
+    .unwrap();
+
+    zk_modifier.ensure_path("/base").unwrap();
+
+    let (snd, rcv) = mpsc::channel::<()>();
+    zk_watcher.add_watch("/base", AddWatchMode::Persistent, move |_| {
+        snd.send(()).unwrap();
+    }).unwrap();
+    zk_modifier.set_data("/base", b"hello1".to_vec(), None).unwrap();
+    rcv.recv_timeout(Duration::from_millis(100)).unwrap();
+    zk_modifier.set_data("/base", b"hello2".to_vec(), None).unwrap();
+    rcv.recv_timeout(Duration::from_millis(100)).unwrap();
+}
+
+#[test]
+fn persistent_watch_does_not_receive_children_changes() {
+    let _ = env_logger::try_init();
+
+    // Create a test cluster
+    let cluster = ZkCluster::start(1);
+
+    let zk_watcher = ZooKeeper::connect(
+        &cluster.connect_string,
+        Duration::from_secs(30),
+        |event: WatchedEvent| info!("{:?}", event),
+    )
+    .unwrap();
+
+    let zk_modifier = ZooKeeper::connect(
+        &cluster.connect_string,
+        Duration::from_secs(30),
+        |event: WatchedEvent| info!("{:?}", event),
+    )
+    .unwrap();
+
+    zk_modifier.ensure_path("/base").unwrap();
+    zk_modifier.ensure_path("/base/child").unwrap();
+
+    let (snd, rcv) = mpsc::channel::<()>();
+    zk_watcher.add_watch("/base", AddWatchMode::Persistent, move |_| {
+        snd.send(()).unwrap();
+    }).unwrap();
+    zk_modifier.set_data("/base", b"hello1".to_vec(), None).unwrap();
+    rcv.recv_timeout(Duration::from_millis(100)).unwrap();
+    zk_modifier.set_data("/base/child", b"hello2".to_vec(), None).unwrap();
+    if rcv.recv_timeout(Duration::from_millis(100)).is_ok() {
+        panic!("received unexpected event for child");
+    }
+}
+
+#[test]
+fn persistent_recursive_watch_stops_receiving_updates_when_removed() {
+    let _ = env_logger::try_init();
+
+    // Create a test cluster
+    let cluster = ZkCluster::start(1);
+
+    let zk_watcher = ZooKeeper::connect(
+        &cluster.connect_string,
+        Duration::from_secs(30),
+        |event: WatchedEvent| info!("{:?}", event),
+    )
+    .unwrap();
+
+    let zk_modifier = ZooKeeper::connect(
+        &cluster.connect_string,
+        Duration::from_secs(30),
+        |event: WatchedEvent| info!("{:?}", event),
+    )
+    .unwrap();
+
+    zk_modifier.ensure_path("/base").unwrap();
+
+    let (snd, rcv) = mpsc::channel::<()>();
+    zk_watcher.add_watch("/base", AddWatchMode::PersistentRecursive, move |_| {
+        snd.send(()).unwrap();
+    }).unwrap();
+    zk_modifier.create("/base/child1", b"hello2".to_vec(), Acl::open_unsafe().clone(), CreateMode::Persistent).unwrap();
+    rcv.recv_timeout(Duration::from_millis(100)).unwrap();
+    zk_watcher.remove_watches("/base", WatcherType::Any).unwrap();
+    zk_modifier.create("/base/child2", b"hello2".to_vec(), Acl::open_unsafe().clone(), CreateMode::Persistent).unwrap();
+    if rcv.recv_timeout(Duration::from_millis(100)).is_ok() {
+        panic!("received unexpected event for child");
+    }
+}
+
+#[test]
+fn persistent_recursive_watch_receive_children_changes() {
+    let _ = env_logger::try_init();
+
+    // Create a test cluster
+    let cluster = ZkCluster::start(1);
+
+    let zk_watcher = ZooKeeper::connect(
+        &cluster.connect_string,
+        Duration::from_secs(30),
+        |event: WatchedEvent| info!("{:?}", event),
+    )
+    .unwrap();
+
+    let zk_modifier = ZooKeeper::connect(
+        &cluster.connect_string,
+        Duration::from_secs(30),
+        |event: WatchedEvent| info!("{:?}", event),
+    )
+    .unwrap();
+
+    zk_modifier.ensure_path("/base").unwrap();
+
+    let (snd, rcv) = mpsc::channel::<()>();
+    zk_watcher.add_watch("/base", AddWatchMode::PersistentRecursive, move |_| {
+        snd.send(()).unwrap();
+    }).unwrap();
+    zk_modifier.create("/base/child1", b"hello2".to_vec(), Acl::open_unsafe().clone(), CreateMode::Persistent).unwrap();
+    rcv.recv_timeout(Duration::from_millis(100)).unwrap();
+    zk_modifier.create("/base/child2", b"hello2".to_vec(), Acl::open_unsafe().clone(), CreateMode::Persistent).unwrap();
+    rcv.recv_timeout(Duration::from_millis(100)).unwrap();
+}


### PR DESCRIPTION
I am opening this pull request to introduce persistent (recursive) watches to the client, since this is one of the missing features right now.

I am making this a draft so that we can discuss the approach.

The idea is to keep two separate pools of watchers since we drop non-persistent watchers on the first event but we want to keep the others. Triggering the watches will remove them from the one-shot list, and keep them in the persistent one. There is an opportunity to refactor the whole way that watchers are managed, but that can be considered separately. (See for example https://github.com/kezhuw/zookeeper-client-rust/blob/master/src/session/watch.rs#L306 where watchers are using channels).

When implementing this I also removed some type duplication for watch types which unfortunately leak into the public API of the library.

I'm not sure whether you would like to proceed with a breaking change or try to keep things backwards compatible by wrapping the Zookeeper types.