### PR TITLE
Add support for tcp keepalive

### DIFF
--- a/examples/leader_latch.rs
+++ b/examples/leader_latch.rs
@@ -28,7 +28,7 @@ fn main() {
     let zk_urls = zk_server_urls();
     log::info!("connecting to {}", zk_urls);
 
-    let zk = ZooKeeper::connect(&*zk_urls, Duration::from_millis(2500), NoopWatcher).unwrap();
+    let zk = ZooKeeper::connect(&*zk_urls, Duration::from_millis(2500), NoopWatcher, None).unwrap();
 
     let id = Uuid::new_v4().to_string();
     log::info!("starting host with id: {:?}", id);

--- a/examples/persistent_watches.rs
+++ b/examples/persistent_watches.rs
@@ -34,11 +34,11 @@ fn zk_example() {
 
     let root = format!("/example-{}", uuid::Uuid::new_v4());
     let modifying_zk =
-        ZooKeeper::connect(&*zk_urls, Duration::from_secs(15), LoggingWatcher).unwrap();
+        ZooKeeper::connect(&*zk_urls, Duration::from_secs(15), LoggingWatcher, None).unwrap();
     let recursive_watch_zk =
-        ZooKeeper::connect(&*zk_urls, Duration::from_secs(15), LoggingWatcher).unwrap();
+        ZooKeeper::connect(&*zk_urls, Duration::from_secs(15), LoggingWatcher, None).unwrap();
     let persistent_watch_zk =
-        ZooKeeper::connect(&*zk_urls, Duration::from_secs(15), LoggingWatcher).unwrap();
+        ZooKeeper::connect(&*zk_urls, Duration::from_secs(15), LoggingWatcher, None).unwrap();
 
     // Creating separate clients to show the example where modifications to the nodes
     // take place in a different session than our own.
@@ -47,8 +47,10 @@ fn zk_example() {
     // Also separate clients per type of watch as there is a bug when creating multiple type watchers in the same
     // path in the same session
     // https://issues.apache.org/jira/browse/ZOOKEEPER-4466
-    recursive_watch_zk.add_listener(|zk_state| println!("New recursive watch ZkState is {:?}", zk_state));
-    persistent_watch_zk.add_listener(|zk_state| println!("New peristent watch ZkState is {:?}", zk_state));
+    recursive_watch_zk
+        .add_listener(|zk_state| println!("New recursive watch ZkState is {:?}", zk_state));
+    persistent_watch_zk
+        .add_listener(|zk_state| println!("New peristent watch ZkState is {:?}", zk_state));
 
     modifying_zk.ensure_path(&root).unwrap();
 
@@ -64,7 +66,9 @@ fn zk_example() {
         })
         .unwrap();
 
-    println!("press c to add and modify child, e to edit the watched node, anything else to proceed");
+    println!(
+        "press c to add and modify child, e to edit the watched node, anything else to proceed"
+    );
     let stdin = io::stdin();
     let inputs = stdin.lock().lines();
     let mut incr = 0;
@@ -82,28 +86,18 @@ fn zk_example() {
                     )
                     .unwrap();
                 modifying_zk
-                    .set_data(
-                        &child_path,
-                        b"new-data".to_vec(),
-                        None,
-                    )
+                    .set_data(&child_path, b"new-data".to_vec(), None)
                     .unwrap();
-                modifying_zk
-                    .delete(&child_path, None)
-                    .unwrap();
-            },
+                modifying_zk.delete(&child_path, None).unwrap();
+            }
             "e" => {
                 modifying_zk
-                    .set_data(
-                        &root,
-                        format!("new-data-{incr}").into_bytes(),
-                        None,
-                    )
+                    .set_data(&root, format!("new-data-{incr}").into_bytes(), None)
                     .unwrap();
             }
             other => {
                 println!("received {other}");
-                break
+                break;
             }
         }
     }

--- a/examples/queue_consume.rs
+++ b/examples/queue_consume.rs
@@ -26,17 +26,18 @@ fn main() {
     let zk_urls = zk_server_urls();
     log::info!("connecting to {}", zk_urls);
 
-    let zk = ZooKeeper::connect(&*zk_urls, Duration::from_millis(2500), NoopWatcher).unwrap();
+    let zk = ZooKeeper::connect(&*zk_urls, Duration::from_millis(2500), NoopWatcher, None).unwrap();
 
     let queue = ZkQueue::new(Arc::new(zk), "/testing2".to_string()).unwrap();
 
     println!("waiting for a message");
     let msg = queue.take();
     if msg.is_err() {
-        eprint!("unable to listen for message. error: {}", msg.err().unwrap().to_string())
+        eprint!(
+            "unable to listen for message. error: {}",
+            msg.err().unwrap().to_string()
+        )
     } else {
         println!("got {:?}", String::from_utf8(msg.unwrap()).unwrap());
-
     }
-
 }

--- a/examples/queue_producer.rs
+++ b/examples/queue_producer.rs
@@ -26,13 +26,11 @@ fn main() {
     let zk_urls = zk_server_urls();
     log::info!("connecting to {}", zk_urls);
 
-    let zk = ZooKeeper::connect(&*zk_urls, Duration::from_millis(2500), NoopWatcher).unwrap();
+    let zk = ZooKeeper::connect(&*zk_urls, Duration::from_millis(2500), NoopWatcher, None).unwrap();
 
     let queue = ZkQueue::new(Arc::new(zk), "/testing2".to_string()).unwrap();
-
 
     let message = "Hello World";
     let op = queue.offer(Vec::from(message.as_bytes()));
     println!("{:?}", op);
-
 }

--- a/examples/zookeeper_example.rs
+++ b/examples/zookeeper_example.rs
@@ -4,14 +4,14 @@ extern crate zookeeper;
 extern crate log;
 extern crate env_logger;
 
-use std::io;
-use std::sync::Arc;
-use std::time::Duration;
-use std::thread;
 use std::env;
+use std::io;
 use std::sync::mpsc;
-use zookeeper::{Acl, CreateMode, Watcher, WatchedEvent, ZooKeeper};
+use std::sync::Arc;
+use std::thread;
+use std::time::Duration;
 use zookeeper::recipes::cache::PathChildrenCache;
+use zookeeper::{Acl, CreateMode, WatchedEvent, Watcher, ZooKeeper};
 
 struct LoggingWatcher;
 impl Watcher for LoggingWatcher {
@@ -28,12 +28,11 @@ fn zk_server_urls() -> String {
     }
 }
 
-
 fn zk_example() {
     let zk_urls = zk_server_urls();
     println!("connecting to {}", zk_urls);
 
-    let zk = ZooKeeper::connect(&*zk_urls, Duration::from_secs(15), LoggingWatcher).unwrap();
+    let zk = ZooKeeper::connect(&*zk_urls, Duration::from_secs(15), LoggingWatcher, None).unwrap();
 
     zk.add_listener(|zk_state| println!("New ZkState is {:?}", zk_state));
 
@@ -43,10 +42,12 @@ fn zk_example() {
 
     println!("authenticated -> {:?}", auth);
 
-    let path = zk.create("/test",
-                         vec![1, 2],
-                         Acl::open_unsafe().clone(),
-                         CreateMode::Ephemeral);
+    let path = zk.create(
+        "/test",
+        vec![1, 2],
+        Acl::open_unsafe().clone(),
+        CreateMode::Ephemeral,
+    );
 
     println!("created -> {:?}", path);
 

--- a/tests/test_cache.rs
+++ b/tests/test_cache.rs
@@ -1,13 +1,12 @@
+use zookeeper::recipes::cache::PathChildrenCache;
 use zookeeper::CreateMode::*;
 use zookeeper::{Acl, WatchedEvent, ZooKeeper, ZooKeeperExt};
-use zookeeper::recipes::cache::PathChildrenCache;
 
 use ZkCluster;
 
+use env_logger;
 use std::sync::Arc;
 use std::time::Duration;
-use env_logger;
-
 
 #[test]
 fn path_children_cache_test() {
@@ -17,15 +16,38 @@ fn path_children_cache_test() {
     let cluster = ZkCluster::start(1);
 
     // Connect to the test cluster
-    let zk = Arc::new(ZooKeeper::connect(&cluster.connect_string,
-                                         Duration::from_secs(30),
-                                         |event: WatchedEvent| info!("{:?}", event))
-                          .unwrap());
+    let zk = Arc::new(
+        ZooKeeper::connect(
+            &cluster.connect_string,
+            Duration::from_secs(30),
+            |event: WatchedEvent| info!("{:?}", event),
+            None,
+        )
+        .unwrap(),
+    );
 
     zk.ensure_path("/cache").unwrap();
-    zk.create("/cache/a", vec![1, 4], Acl::open_unsafe().clone(), Ephemeral).unwrap();
-    zk.create("/cache/b", vec![2, 4], Acl::open_unsafe().clone(), Ephemeral).unwrap();
-    zk.create("/cache/c", vec![3, 4], Acl::open_unsafe().clone(), Ephemeral).unwrap();
+    zk.create(
+        "/cache/a",
+        vec![1, 4],
+        Acl::open_unsafe().clone(),
+        Ephemeral,
+    )
+    .unwrap();
+    zk.create(
+        "/cache/b",
+        vec![2, 4],
+        Acl::open_unsafe().clone(),
+        Ephemeral,
+    )
+    .unwrap();
+    zk.create(
+        "/cache/c",
+        vec![3, 4],
+        Acl::open_unsafe().clone(),
+        Ephemeral,
+    )
+    .unwrap();
 
     let path_children_cache = Arc::new(PathChildrenCache::new(zk, "/cache").unwrap());
 

--- a/tests/test_leader.rs
+++ b/tests/test_leader.rs
@@ -1,7 +1,7 @@
+use env_logger;
+use std::{sync::Arc, thread, time::Duration};
 use uuid::Uuid;
 use zookeeper::{recipes::leader::LeaderLatch, ZkResult, ZooKeeper};
-use env_logger;
-use std::{sync::Arc, time::Duration, thread};
 use ZkCluster;
 
 #[test]
@@ -14,6 +14,7 @@ fn leader_latch_test() -> ZkResult<()> {
         &cluster.connect_string,
         Duration::from_secs(30),
         |_ev| {},
+        None,
     )?);
 
     let id1 = Uuid::new_v4().to_string();
@@ -58,6 +59,7 @@ fn leader_latch_test_disconnect() -> ZkResult<()> {
         &cluster.connect_string,
         Duration::from_secs(30),
         |_ev| {},
+        None,
     )?);
 
     let id = Uuid::new_v4().to_string();

--- a/tests/test_recursive.rs
+++ b/tests/test_recursive.rs
@@ -15,7 +15,9 @@ fn get_children_recursive_test() {
         &cluster.connect_string,
         Duration::from_secs(30),
         |_: WatchedEvent| {},
-    ).unwrap();
+        None,
+    )
+    .unwrap();
 
     let tree = vec![
         "/root/a/1",
@@ -35,7 +37,8 @@ fn get_children_recursive_test() {
 
     let children = zk.get_children_recursive("/root").unwrap();
     for path in tree {
-        for (i, _) in path.chars()
+        for (i, _) in path
+            .chars()
             .chain(once('/'))
             .enumerate()
             .skip(1)
@@ -56,7 +59,9 @@ fn get_children_recursive_invalid_path_test() {
         &cluster.connect_string,
         Duration::from_secs(30),
         |_: WatchedEvent| {},
-    ).unwrap();
+        None,
+    )
+    .unwrap();
 
     let result = zk.get_children_recursive("/bad");
     assert_eq!(result, Err(ZkError::NoNode))
@@ -72,7 +77,9 @@ fn get_children_recursive_only_root_test() {
         &cluster.connect_string,
         Duration::from_secs(30),
         |_: WatchedEvent| {},
-    ).unwrap();
+        None,
+    )
+    .unwrap();
 
     let root = "/root";
     zk.ensure_path(root).unwrap();
@@ -90,7 +97,9 @@ fn delete_recursive_test() {
         &cluster.connect_string,
         Duration::from_secs(30),
         |_: WatchedEvent| {},
-    ).unwrap();
+        None,
+    )
+    .unwrap();
 
     let tree = vec![
         "/root/a/1",
@@ -123,7 +132,9 @@ fn delete_recursive_invalid_path_test() {
         &cluster.connect_string,
         Duration::from_secs(30),
         |_: WatchedEvent| {},
-    ).unwrap();
+        None,
+    )
+    .unwrap();
 
     let result = zk.delete_recursive("/bad");
     assert_eq!(result, Err(ZkError::NoNode))

--- a/tests/test_zk.rs
+++ b/tests/test_zk.rs
@@ -1,14 +1,13 @@
-use zookeeper::{Acl, CreateMode, WatchedEvent, ZooKeeper};
 use zookeeper::KeeperState;
+use zookeeper::{Acl, CreateMode, WatchedEvent, ZooKeeper};
 
 use ZkCluster;
 
-use std::sync::Arc;
-use std::sync::atomic::{AtomicUsize, Ordering};
-use std::time::Duration;
-use std::thread;
 use env_logger;
-
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::thread;
+use std::time::Duration;
 
 #[test]
 fn zk_test() {
@@ -21,32 +20,33 @@ fn zk_test() {
     let disconnects_watcher = disconnects.clone();
 
     // Connect to the test cluster
-    let zk = ZooKeeper::connect(&cluster.connect_string,
-                                Duration::from_secs(5),
-                                move |event: WatchedEvent| {
-                                    info!("{:?}", event);
-                                    if event.keeper_state == KeeperState::Disconnected {
-                                        disconnects_watcher.fetch_add(1, Ordering::Relaxed);
-                                    }
-                                })
-                 .unwrap();
-
+    let zk = ZooKeeper::connect(
+        &cluster.connect_string,
+        Duration::from_secs(5),
+        move |event: WatchedEvent| {
+            info!("{:?}", event);
+            if event.keeper_state == KeeperState::Disconnected {
+                disconnects_watcher.fetch_add(1, Ordering::Relaxed);
+            }
+        },
+        None,
+    )
+    .unwrap();
 
     // Do the tests
-    let create = zk.create("/test",
-                           vec![8, 8],
-                           Acl::open_unsafe().clone(),
-                           CreateMode::Ephemeral);
+    let create = zk.create(
+        "/test",
+        vec![8, 8],
+        Acl::open_unsafe().clone(),
+        CreateMode::Ephemeral,
+    );
     assert_eq!(create.ok(), Some("/test".to_owned()));
-
 
     let exists = zk.exists("/test", true);
     assert!(exists.is_ok());
 
-
     // Check that during inactivity, pinging keeps alive the connection
     thread::sleep(Duration::from_secs(8));
-
 
     // Set/Get Big-Data(tm)
     let data = vec![7; 1024 * 1000];
@@ -64,12 +64,12 @@ fn zk_test() {
     let delete = zk.delete("/test", None);
     assert!(delete.is_ok());
 
-
     let mut sorted_children = children.unwrap();
     sorted_children.sort();
-    assert_eq!(sorted_children,
-               vec!["test".to_owned(), "zookeeper".to_owned()]);
-
+    assert_eq!(
+        sorted_children,
+        vec!["test".to_owned(), "zookeeper".to_owned()]
+    );
 
     // Let's see what happens when the connected server goes down
     assert_eq!(disconnects.load(Ordering::Relaxed), 0);
@@ -81,13 +81,11 @@ fn zk_test() {
     // TODO once `manual` events are possible
     // assert_eq!(disconnects.load(Ordering::Relaxed), 1);
 
-
     // After closing the client all operations return Err
     zk.close().unwrap();
 
     let exists = zk.exists("/test", true);
     assert!(exists.is_err());
-
 
     // Close the whole cluster
     cluster.shutdown();


### PR DESCRIPTION
Hey, we have a lot of issues with this crate disconnecting from the network and making the whole process crash, basically.
It's strange because we didn't have any issues at the time when we were using https://docs.rs/zookeeper-client/latest/zookeeper_client/
Do you know what could be the culprit?
We're running with the exact same zookeeper version.

I thought adding support for tcp-keepalive could maybe help, but I doubt it.
Fix https://github.com/bonifaido/rust-zookeeper/issues/92

Also, since we establishes the connection straight away in the `new` and don't use a builder or something, I had to introduce a new parameter in the `new` function which is a breaking change 🥺 